### PR TITLE
Make config location editable via option

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Crunz\Configuration;
 
 use Crunz\Application\Service\ConfigurationInterface;
+use Crunz\Console\Command\ConfigGeneratorCommand;
 use Crunz\Filesystem\FilesystemInterface;
 use Crunz\Path\Path;
 

--- a/src/Configuration/ConfigurationParser.php
+++ b/src/Configuration/ConfigurationParser.php
@@ -64,9 +64,9 @@ final class ConfigurationParser implements ConfigurationParserInterface
         $cwd = $this->filesystem
             ->getCwd();
         
-        $configFileName = $configFileName = getenv('CRUNZ_CONFIG') ?: ConfigGeneratorCommand::CONFIG_FILE_NAME;
+        $configFileName = ConfigGeneratorCommand::$CONFIG_FILE_NAME;
         
-        $configPath = Path::fromStrings($cwd ?? '', $configFileName->toString();
+        $configPath = Path::fromStrings($cwd ?? '', $configFileName)->toString();
         $configExists = $this->filesystem
             ->fileExists($configPath);
 

--- a/src/Configuration/ConfigurationParser.php
+++ b/src/Configuration/ConfigurationParser.php
@@ -63,7 +63,10 @@ final class ConfigurationParser implements ConfigurationParserInterface
     {
         $cwd = $this->filesystem
             ->getCwd();
-        $configPath = Path::fromStrings($cwd ?? '', ConfigGeneratorCommand::CONFIG_FILE_NAME)->toString();
+        
+        $configFileName = $configFileName = getenv('CRUNZ_CONFIG') ?: ConfigGeneratorCommand::CONFIG_FILE_NAME;
+        
+        $configPath = Path::fromStrings($cwd ?? '', $configFileName->toString();
         $configExists = $this->filesystem
             ->fileExists($configPath);
 

--- a/src/Console/Command/ConfigGeneratorCommand.php
+++ b/src/Console/Command/ConfigGeneratorCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 final class ConfigGeneratorCommand extends Command
 {
-    public const CONFIG_FILE_NAME = 'crunz.yml';
+    public static string $CONFIG_FILE_NAME = 'crunz.yml';
 
     public function __construct(
         private ProviderInterface $timezoneProvider,
@@ -45,7 +45,7 @@ final class ConfigGeneratorCommand extends Command
         $symfonyStyleIo = new SymfonyStyle($input, $output);
         $cwd = $this->filesystem
             ->getCwd();
-        $path = Path::create([$cwd, self::CONFIG_FILE_NAME])->toString();
+        $path = Path::create([$cwd, self::$CONFIG_FILE_NAME])->toString();
         $destination = \realpath($path) ?: $path;
         $configExists = $this->filesystem
             ->fileExists($destination)
@@ -70,7 +70,7 @@ final class ConfigGeneratorCommand extends Command
             $projectRoot,
             'resources',
             'config',
-            self::CONFIG_FILE_NAME
+            self::$CONFIG_FILE_NAME
         );
         $src = $srcPath->toString();
         $output->writeln(

--- a/tests/EndToEnd/ConfigProviderTest.php
+++ b/tests/EndToEnd/ConfigProviderTest.php
@@ -19,7 +19,7 @@ final class ConfigProviderTest extends EndToEndTestCase
         $environment = $environmentBuilder->createEnvironment();
         $process = $environment->runCrunzCommand('publish:config');
 
-        $configPath = Path::fromStrings($environment->rootDirectory(), ConfigGeneratorCommand::CONFIG_FILE_NAME);
+        $configPath = Path::fromStrings($environment->rootDirectory(), ConfigGeneratorCommand::$CONFIG_FILE_NAME);
         $filesystem = new Filesystem();
 
         self::assertTrue($process->isSuccessful(), "Process output: {$process->getOutput()}{$process->errorOutput()}");

--- a/tests/TestCase/EndToEnd/Environment/Environment.php
+++ b/tests/TestCase/EndToEnd/Environment/Environment.php
@@ -135,7 +135,7 @@ final class Environment
 
         $configPath = Path::fromStrings(
             $this->rootDirectory,
-            ConfigGeneratorCommand::CONFIG_FILE_NAME
+            ConfigGeneratorCommand::$CONFIG_FILE_NAME
         );
 
         $yamlConfig = Yaml::dump($this->config);


### PR DESCRIPTION
This makes it posible to define an alternative location for your config file. For example you want it inside a config folder or outside your project root. 

Simply define the env variable CRUNZ_CONFIG in your environment or export before executing the command:
ie: export CRUNZ_CONFIG=config/crunz.yml && php vendor/bin/crunz

| Q             | A
| ------------- | ---
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
