### PR TITLE
Getter for 'from' and  'to' event's configuration

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -462,6 +462,7 @@ class Event implements PingableInterface
     public function from($datetime)
     {
         $this->disply_from = $datetime;
+
         return $this->skip(fn () => $this->notYet($datetime));
     }
 
@@ -475,6 +476,7 @@ class Event implements PingableInterface
     public function to($datetime)
     {
         $this->disply_to = $datetime;
+
         return $this->skip(fn () => $this->past($datetime));
     }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -89,14 +89,14 @@ class Event implements PingableInterface
     protected $timezone;
 
     /**
-     * Datetime or time since the task is evaluated and possibly executed (only for display purposes)
+     * Datetime or time since the task is evaluated and possibly executed only for display purposes.
      *
      * @var \DateTime|null
      */
     protected $disply_from = null;
 
     /**
-     * Datetime or time until the task is evaluated and possibly executed (only for display purposes)
+     * Datetime or time until the task is evaluated and possibly executed only for display purposes.
      *
      * @var \DateTime|null
      */
@@ -474,7 +474,7 @@ class Event implements PingableInterface
      */
     public function to($datetime)
     {
-        $this->disply_to  = $datetime;
+        $this->disply_to = $datetime;
         return $this->skip(fn () => $this->past($datetime));
     }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -91,14 +91,14 @@ class Event implements PingableInterface
     /**
      * Datetime or time since the task is evaluated and possibly executed only for display purposes.
      *
-     * @var \DateTime|null
+     * @var \DateTime|string|null
      */
     protected $disply_from = null;
 
     /**
      * Datetime or time until the task is evaluated and possibly executed only for display purposes.
      *
-     * @var \DateTime|null
+     * @var \DateTime|string|null
      */
     protected $disply_to = null;
 
@@ -942,7 +942,7 @@ class Event implements PingableInterface
     /**
      * Get the 'from' configuration for the event if present.
      *
-     * @return \DateTime|null
+     * @return \DateTime|string|null
      */
     public function getFrom()
     {
@@ -952,7 +952,7 @@ class Event implements PingableInterface
     /**
      * Get the 'to' configuration for the event if present.
      *
-     * @return \DateTime|null
+     * @return \DateTime|string|null
      */
     public function getTo()
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -89,6 +89,20 @@ class Event implements PingableInterface
     protected $timezone;
 
     /**
+     * Datetime or time since the task is evaluated and possibly executed (only for display purposes)
+     *
+     * @var \DateTime|null
+     */
+    protected $disply_from = null;
+
+    /**
+     * Datetime or time until the task is evaluated and possibly executed (only for display purposes)
+     *
+     * @var \DateTime|null
+     */
+    protected $disply_to = null;
+
+    /**
      * The user the command should run as.
      *
      * @var string
@@ -447,6 +461,7 @@ class Event implements PingableInterface
      */
     public function from($datetime)
     {
+        $this->disply_from = $datetime;
         return $this->skip(fn () => $this->notYet($datetime));
     }
 
@@ -459,6 +474,7 @@ class Event implements PingableInterface
      */
     public function to($datetime)
     {
+        $this->disply_to  = $datetime;
         return $this->skip(fn () => $this->past($datetime));
     }
 
@@ -919,6 +935,26 @@ class Event implements PingableInterface
     public function getExpression()
     {
         return $this->expression;
+    }
+
+    /**
+     * Get the 'from' configuration for the event if present.
+     *
+     * @return \DateTime|null
+     */
+    public function getFrom()
+    {
+        return $this->disply_from;
+    }
+
+    /**
+     * Get the 'to' configuration for the event if present.
+     *
+     * @return \DateTime|null
+     */
+    public function getTo()
+    {
+        return $this->disply_to;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed issue | #59

Inside the Event class there are several methods that allow you to have details on the individual task such as getId(), getSummaryForDisplay(), getExpression(), etc..

However, by setting the task lifetime with the beetween(), from() or to() methods there is no way to read this configuration from the class.

I added two protected variables that allow saving the from and to information, which will only be used for displaying the information and will not influence the behavior of the Event class in any way. I then added the two methods getFrom() and getTo() to display the information.
