### PR TITLE
Add possibility to change base cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,6 +908,10 @@ As you can see there are a few options like `source` which is used to specify th
 
 Each time we run Crunz commands, it will look into the project's root directory to see if there's any user-modified configuration file. If the configuration file doesn't exists, it will use the one shipped with the package.
 
+## Setting the base cache directory
+
+You can change the base cache directory of crunz by setting the `CRUNZ_BASE_CACHE_DIR` environment variable.
+The default base cache directory is `\sys_get_temp_dir()`. The subdirectory `.crunz` is always added to the base cache directory.
 
 ## Development ENV flags
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Crunz;
 
+use Crunz\CacheDirectoryFactory\CacheDirectoryFactory;
 use Crunz\Console\Command\ConfigGeneratorCommand;
 use Crunz\Console\Command\ScheduleListCommand;
 use Crunz\Console\Command\ScheduleRunCommand;
@@ -60,11 +61,13 @@ class Application extends SymfonyApplication
 
     private Container $container;
     private readonly EnvFlags $envFlags;
+    private readonly CacheDirectoryFactory $cacheDirectoryFactory;
 
     public function __construct(string $appName, string $appVersion)
     {
         parent::__construct($appName, $appVersion);
 
+        $this->cacheDirectoryFactory = new CacheDirectoryFactory();
         $this->envFlags = new EnvFlags();
 
         $this->initializeContainer();
@@ -208,19 +211,9 @@ class Application extends SymfonyApplication
         return \is_writable($baseCacheDir);
     }
 
-    /**
-     * @return string
-     */
-    private function getBaseCacheDir()
+    private function getBaseCacheDir(): string
     {
-        $baseCacheDir = Path::create(
-            [
-                \sys_get_temp_dir(),
-                '.crunz',
-            ]
-        );
-
-        return $baseCacheDir->toString();
+        return $this->cacheDirectoryFactory->generate()->toString();
     }
 
     /**

--- a/src/CacheDirectoryFactory/CacheDirectoryFactory.php
+++ b/src/CacheDirectoryFactory/CacheDirectoryFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\CacheDirectoryFactory;
+
+use Crunz\Exception\CrunzException;
+use Crunz\Path\Path;
+
+final class CacheDirectoryFactory
+{
+    public const CRUNZ_BASE_CACHE_DIR = 'CRUNZ_BASE_CACHE_DIR';
+
+    /**
+     * @throws CrunzException
+     */
+    public function generate(): Path
+    {
+        $cacheDirectory = '.crunz';
+        /** @var false|string $basePath */
+        $basePath = \getenv(self::CRUNZ_BASE_CACHE_DIR, true);
+        if (false === $basePath) {
+            return Path::fromStrings(\sys_get_temp_dir(), $cacheDirectory);
+        }
+
+        $basePath = \ltrim($basePath);
+        if ('' === $basePath) {
+            throw new CrunzException('Crunz base cache directory path is empty.');
+        }
+
+        return Path::fromStrings($basePath, $cacheDirectory);
+    }
+}

--- a/tests/Functional/DifferentBaseCacheDirTest.php
+++ b/tests/Functional/DifferentBaseCacheDirTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\Functional;
+
+use Crunz\Application;
+use Crunz\CacheDirectoryFactory\CacheDirectoryFactory;
+use PHPUnit\Framework\TestCase;
+
+final class DifferentBaseCacheDirTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @runInSeparateProcess
+     */
+    public function different_base_cache_dir_is_used(): void
+    {
+        $newTmpDir = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'newBaseCacheDir';
+        \putenv(CacheDirectoryFactory::CRUNZ_BASE_CACHE_DIR . "={$newTmpDir}");
+
+        new Application('Crunz', '0.1.0-test.1');
+
+        self::assertDirectoryExists($newTmpDir);
+    }
+}

--- a/tests/Unit/CacheDirectoryFactory/CacheDirectoryFactoryTest.php
+++ b/tests/Unit/CacheDirectoryFactory/CacheDirectoryFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\Unit\CacheDirectoryFactory;
+
+use Crunz\CacheDirectoryFactory\CacheDirectoryFactory;
+use Crunz\Exception\CrunzException;
+use Crunz\Path\Path;
+use PHPUnit\Framework\TestCase;
+
+final class CacheDirectoryFactoryTest extends TestCase
+{
+    /** @test  */
+    public function sys_temp_dir_is_default_directory(): void
+    {
+        $cacheDirectoryFactory = new CacheDirectoryFactory();
+
+        $result = $cacheDirectoryFactory->generate();
+
+        $expectedResult = Path::fromStrings(\sys_get_temp_dir(), '.crunz');
+        self::assertEquals($expectedResult, $result);
+    }
+
+    /** @test */
+    public function change_cache_directory_through_environment_variable(): void
+    {
+        $newDirectoryPath = '/new/directory/path';
+        \putenv(CacheDirectoryFactory::CRUNZ_BASE_CACHE_DIR . "={$newDirectoryPath}");
+        $cacheDirectoryFactory = new CacheDirectoryFactory();
+
+        $result = $cacheDirectoryFactory->generate();
+
+        $expectedResult = Path::fromStrings($newDirectoryPath, '.crunz');
+        self::assertEquals($expectedResult, $result);
+    }
+
+    /** @test */
+    public function throw_exception_when_environment_variable_is_empty(): void
+    {
+        $newDirectoryPath = '   ';
+        \putenv(CacheDirectoryFactory::CRUNZ_BASE_CACHE_DIR . "={$newDirectoryPath}");
+        $cacheDirectoryFactory = new CacheDirectoryFactory();
+
+        self::expectException(CrunzException::class);
+
+        $cacheDirectoryFactory->generate();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #58 

This is a simple and uninvasive solution for having the possibility to configure the cache directory of crunz. I have not put this into the EnvFlags, as it is not a development Flag. To have an additional configuration option for this, you would need to change some of the underlying structure of the Application class and how the configs are loaded and cached.
