### PR TITLE
Expiring lock stores & lock's TTL fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,11 @@ $task
     ->preventOverlapping($store);
 
 ```
+Optionally, you can specify a TTL (Time To Live) for the lock
+
+```php
+$task->preventOverlapping($store, 60); // Lock expires after 60 seconds
+```
 
 ## Keeping the Output
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -704,7 +704,7 @@ class Event implements PingableInterface
      * @param PersistingStoreInterface|object $store
      * @param int|null $ttl
      * @return $this
-     * @throws \Crunz\Exception\CrunzException
+     * @throws CrunzException
      */
     public function preventOverlapping(?object $store = null, ?int $ttl = 30)
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -701,9 +701,11 @@ class Event implements PingableInterface
      * By default, the lock is acquired through file system locks. Alternatively, you can pass a symfony lock store
      * that will be responsible for the locking.
      *
-     * @param PersistingStoreInterface|object $store
-     * @param int|null $ttl
+     * @param PersistingStoreInterface|object|null $store A symfony lock store
+     * @param int|null                             $ttl   Time To Live of the lock in seconds
+     *
      * @return $this
+     *
      * @throws CrunzException
      */
     public function preventOverlapping(?object $store = null, ?int $ttl = 30)
@@ -1019,11 +1021,11 @@ class Event implements PingableInterface
         }
 
         // If the lock has remaining lifetime (i.e. the method returns a float and not NULL), that means the LockStore does support TTL [ 'MemcachedStore', 'MongoDbStore' , 'PdoStore', 'DoctrineDbalStore', 'RedisStore' ]
-        // @see https://symfony.com/doc/6.4/components/lock.html#available-stores
+        // @see https://symfony.com/doc/6.4/components/lock.html#available-stores for detailed information
         $remainingLifetime = $this->lock->getRemainingLifetime();
         if (null !== $remainingLifetime) {
             return;
-        };
+        }
 
         $lock = $this->createLockObject();
         $remainingLifetime = $lock->getRemainingLifetime();
@@ -1103,7 +1105,8 @@ class Event implements PingableInterface
     /**
      * Get the symfony lock object for the task.
      *
-     * @param int|null $ttl
+     * @param int|null $ttl Time To Live of the lock in seconds
+     *
      * @return Lock
      */
     protected function createLockObject(?int $ttl = 30)

--- a/src/Event.php
+++ b/src/Event.php
@@ -1009,13 +1009,21 @@ class Event implements PingableInterface
     }
 
     /**
-     * If this event is prevented from overlapping, this method should be called regularly to refresh the lock.
+     * If this event is prevented from overlapping, this method should be called regularly to refresh the lock,
+     * UNLESS the lock store supports expiring (TTL), which means no refresh is needed.
      */
     public function refreshLock(): void
     {
         if (!$this->preventOverlapping) {
             return;
         }
+
+        // If the lock has remaining lifetime (i.e. the method returns a float and not NULL), that means the LockStore does support TTL [ 'MemcachedStore', 'MongoDbStore' , 'PdoStore', 'DoctrineDbalStore', 'RedisStore' ]
+        // @see https://symfony.com/doc/6.4/components/lock.html#available-stores
+        $remainingLifetime = $this->lock->getRemainingLifetime();
+        if (null !== $remainingLifetime) {
+            return;
+        };
 
         $lock = $this->createLockObject();
         $remainingLifetime = $lock->getRemainingLifetime();

--- a/src/Event.php
+++ b/src/Event.php
@@ -702,10 +702,11 @@ class Event implements PingableInterface
      * that will be responsible for the locking.
      *
      * @param PersistingStoreInterface|object $store
-     *
+     * @param int|null $ttl
      * @return $this
+     * @throws \Crunz\Exception\CrunzException
      */
-    public function preventOverlapping(?object $store = null)
+    public function preventOverlapping(?object $store = null, ?int $ttl = 30)
     {
         if (null !== $store && !($store instanceof PersistingStoreInterface)) {
             $expectedClass = PersistingStoreInterface::class;
@@ -721,8 +722,8 @@ class Event implements PingableInterface
         $this->lockFactory = new LockFactory($lockStore);
 
         // Skip the event if it's locked (processing)
-        $this->skip(function () {
-            $lock = $this->createLockObject();
+        $this->skip(function () use ($ttl) {
+            $lock = $this->createLockObject($ttl);
             $lock->acquire();
 
             return !$lock->isAcquired();
@@ -1094,15 +1095,14 @@ class Event implements PingableInterface
     /**
      * Get the symfony lock object for the task.
      *
+     * @param int|null $ttl
      * @return Lock
      */
-    protected function createLockObject()
+    protected function createLockObject(?int $ttl = 30)
     {
         $this->checkLockFactory();
 
         if (null === $this->lock && null !== $this->lockFactory) {
-            $ttl = 30;
-
             $this->lock = $this->lockFactory
                 ->createLock($this->lockKey(), $ttl);
         }

--- a/src/Event.php
+++ b/src/Event.php
@@ -702,13 +702,13 @@ class Event implements PingableInterface
      * that will be responsible for the locking.
      *
      * @param PersistingStoreInterface|object|null $store A symfony lock store
-     * @param int|null                             $ttl   Time To Live of the lock in seconds
+     * @param int                                  $ttl   Time To Live of the lock in seconds
      *
      * @return $this
      *
      * @throws CrunzException
      */
-    public function preventOverlapping(?object $store = null, ?int $ttl = 30)
+    public function preventOverlapping(?object $store = null, int $ttl = 30)
     {
         if (null !== $store && !($store instanceof PersistingStoreInterface)) {
             $expectedClass = PersistingStoreInterface::class;
@@ -1105,11 +1105,11 @@ class Event implements PingableInterface
     /**
      * Get the symfony lock object for the task.
      *
-     * @param int|null $ttl Time To Live of the lock in seconds
+     * @param int $ttl Time To Live of the lock in seconds
      *
      * @return Lock
      */
-    protected function createLockObject(?int $ttl = 30)
+    protected function createLockObject(int $ttl = 30)
     {
         $this->checkLockFactory();
 

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -476,6 +476,21 @@ final class EventTest extends UnitTestCase
         $event->preventOverlapping($store);
     }
 
+    public function test_expiring_store_can_be_passed_to_prevent_overlapping_with_ttl(): void
+    {
+        // Arrange
+        $store = new PdoStore('');
+        $ttl = 3;
+
+        $event = $this->createEvent();
+
+        // Expect
+        $this->expectNotToPerformAssertions();
+
+        // Act
+        $event->preventOverlapping($store, $ttl);
+    }
+
     /**
      * @param \Closure(): array{
      *     now: \DateTimeImmutable,


### PR DESCRIPTION
- Adding the possibility to specify a TTL (Time To Live) for the lock.
- Stop refreshing the lock's TTL, if the lock store supports [expiring](https://symfony.com/doc/6.4/components/lock.html#available-stores).