### PR TITLE
Event ID implementation

### DIFF
--- a/src/Application/Query/TaskInformation/TaskInformationHandler.php
+++ b/src/Application/Query/TaskInformation/TaskInformationHandler.php
@@ -36,7 +36,7 @@ final class TaskInformationHandler
 
         // List of schedules
         $schedules = $this->taskLoader
-            ->load(...\array_values($files))
+            ->load($source, ...\array_values($files))
         ;
 
         $timezoneForComparisons = $this->timezone

--- a/src/Console/Command/ScheduleListCommand.php
+++ b/src/Console/Command/ScheduleListCommand.php
@@ -93,6 +93,7 @@ class ScheduleListCommand extends \Symfony\Component\Console\Command\Command
      *         number: int,
      *         task: string,
      *         expression: string,
+     *         eventID: int|string,
      *         command: string,
      *     },
      * >
@@ -104,7 +105,7 @@ class ScheduleListCommand extends \Symfony\Component\Console\Command\Command
             ->all($source)
         ;
         $schedules = $this->taskLoader
-            ->load(...\array_values($tasks))
+            ->load($source, ...\array_values($tasks))
         ;
 
         $tasksList = [];
@@ -116,6 +117,7 @@ class ScheduleListCommand extends \Symfony\Component\Console\Command\Command
                 $tasksList[] = [
                     'number' => ++$number,
                     'task' => $event->description ?? '',
+                    'eventID' => $event->getEventID(),
                     'expression' => $event->getExpression(),
                     'command' => $event->getCommandForDisplay(),
                 ];
@@ -148,6 +150,7 @@ class ScheduleListCommand extends \Symfony\Component\Console\Command\Command
      *     array{
      *         number: int,
      *         task: string,
+     *         eventID: int|string,     *
      *         expression: string,
      *         command: string,
      *     },
@@ -165,6 +168,7 @@ class ScheduleListCommand extends \Symfony\Component\Console\Command\Command
                     [
                         '#',
                         'Task',
+                        'Event ID',
                         'Expression',
                         'Command to Run',
                     ]

--- a/src/Console/Command/ScheduleListCommand.php
+++ b/src/Console/Command/ScheduleListCommand.php
@@ -150,7 +150,7 @@ class ScheduleListCommand extends \Symfony\Component\Console\Command\Command
      *     array{
      *         number: int,
      *         task: string,
-     *         eventID: int|string,     *
+     *         eventID: int|string,
      *         expression: string,
      *         command: string,
      *     },

--- a/src/Console/Command/ScheduleRunCommand.php
+++ b/src/Console/Command/ScheduleRunCommand.php
@@ -87,7 +87,7 @@ class ScheduleRunCommand extends Command
 
         // List of schedules
         $schedules = $this->taskLoader
-            ->load(...\array_values($files))
+            ->load($source, ...\array_values($files))
         ;
         $tasksTimezone = $this->taskTimezone
             ->timezoneForComparisons()

--- a/src/Event.php
+++ b/src/Event.php
@@ -51,6 +51,13 @@ class Event implements PingableInterface
     public $description;
 
     /**
+     * The event's unique identifier.
+     *
+     * @var string|int
+     */
+    public $eventID;
+
+    /**
      * Event generated output.
      *
      * @var string|null
@@ -141,6 +148,13 @@ class Event implements PingableInterface
     protected $cwd;
 
     /**
+     * Event source file.
+     *
+     * @var string|null
+     */
+    protected $sourceFile;
+
+    /**
      * Position of cron fields.
      *
      * @var array<string,int>
@@ -183,6 +197,22 @@ class Event implements PingableInterface
     {
         $this->command = $command;
         $this->output = $this->getDefaultOutput();
+    }
+
+    /**
+     * Get or set the source file of the event.
+     *
+     * @param string|null $sourceFile
+     *
+     * @return string|null
+     */
+    public function sourceFile($sourceFile)
+    {
+        if (null !== $sourceFile) {
+            return $this->sourceFile = $sourceFile;
+        }
+
+        return $this->sourceFile;
     }
 
     /**
@@ -864,6 +894,20 @@ class Event implements PingableInterface
     }
 
     /**
+     * Set event ID.
+     *
+     * @param string $eventID
+     *
+     * @return $this
+     */
+    public function eventID($eventID)
+    {
+        $this->eventID = $eventID;
+
+        return $this;
+    }
+
+    /**
      * Another way to the frequency of the cron job.
      *
      * @param string         $unit
@@ -937,6 +981,20 @@ class Event implements PingableInterface
     public function getTo(): \DateTime|string|null
     {
         return $this->to;
+    }
+
+    /**
+     * Get the event ID
+     *
+     * @return string
+     */
+    public function getEventID()
+    {
+        if(empty($this->eventID)){
+            return $this->eventID;
+        }else{
+            return \md5($this->sourceFile . $this->description . $this->expression);
+        }
     }
 
     /**

--- a/src/Event.php
+++ b/src/Event.php
@@ -902,6 +902,13 @@ class Event implements PingableInterface
      */
     public function eventID($eventID)
     {
+        if (empty($eventID)) {
+            throw new CrunzException('Event ID cannot be empty.');
+        }
+        if (!\is_string($eventID) && !\is_int($eventID)) {
+            throw new CrunzException('Event ID must be a string or an integer.');
+        }
+
         $this->eventID = $eventID;
 
         return $this;
@@ -990,7 +997,7 @@ class Event implements PingableInterface
      */
     public function getEventID()
     {
-        if (!empty($this->eventID)) {
+        if (!empty($this->eventID) && \is_string($this->eventID)) {
             return $this->eventID;
         }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -46,7 +46,7 @@ class Event implements PingableInterface
     /**
      * The human readable description of the event.
      *
-     * @var string|null
+     * @var string|null|null
      */
     public $description;
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -51,13 +51,6 @@ class Event implements PingableInterface
     public $description;
 
     /**
-     * The event's unique identifier.
-     *
-     * @var string|int|null
-     */
-    private $eventID;
-
-    /**
      * Event generated output.
      *
      * @var string|null
@@ -166,6 +159,13 @@ class Event implements PingableInterface
         'month' => 4,
         'week' => 5,
     ];
+
+    /**
+     * The event's unique identifier.
+     *
+     * @var string|int|null
+     */
+    private $eventID;
 
     /**
      * Indicates if the command should not overlap itself.

--- a/src/Event.php
+++ b/src/Event.php
@@ -986,7 +986,7 @@ class Event implements PingableInterface
     /**
      * Get the event ID.
      *
-     * @return string
+     * @return string|int
      */
     public function getEventID()
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -902,7 +902,7 @@ class Event implements PingableInterface
      */
     public function eventID($eventID)
     {
-        if (!isset($eventID) || $eventID === null || $eventID === '') {
+        if (!isset($eventID) || null === $eventID || '' === $eventID) {
             throw new CrunzException('Event ID cannot be empty.');
         }
         if (!\is_string($eventID) && !\is_int($eventID)) {
@@ -997,7 +997,7 @@ class Event implements PingableInterface
      */
     public function getEventID()
     {
-        if (isset($this->eventID) && $this->eventID !== null && $this->eventID !== '') {
+        if (isset($this->eventID) && null !== $this->eventID && '' !== $this->eventID) {
             return $this->eventID;
         }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -46,16 +46,16 @@ class Event implements PingableInterface
     /**
      * The human readable description of the event.
      *
-     * @var string|null|null
+     * @var string|null
      */
     public $description;
 
     /**
      * The event's unique identifier.
      *
-     * @var string|int
+     * @var string|int|null
      */
-    public $eventID;
+    private $eventID;
 
     /**
      * Event generated output.

--- a/src/Event.php
+++ b/src/Event.php
@@ -896,7 +896,7 @@ class Event implements PingableInterface
     /**
      * Set event ID.
      *
-     * @param string $eventID
+     * @param string|int|null $eventID
      *
      * @return $this
      */

--- a/src/Event.php
+++ b/src/Event.php
@@ -990,7 +990,7 @@ class Event implements PingableInterface
      */
     public function getEventID()
     {
-        if(empty($this->eventID)){
+        if(!empty($this->eventID)){
             return $this->eventID;
         }else{
             return \md5($this->sourceFile . $this->description . $this->expression);

--- a/src/Event.php
+++ b/src/Event.php
@@ -900,15 +900,8 @@ class Event implements PingableInterface
      *
      * @return $this
      */
-    public function eventID($eventID)
+    public function eventID($eventID = null)
     {
-        if (!isset($eventID) || null === $eventID || '' === $eventID) {
-            throw new CrunzException('Event ID cannot be empty.');
-        }
-        if (!\is_string($eventID) && !\is_int($eventID)) {
-            throw new CrunzException('Event ID must be a string or an integer.');
-        }
-
         $this->eventID = $eventID;
 
         return $this;

--- a/src/Event.php
+++ b/src/Event.php
@@ -984,17 +984,17 @@ class Event implements PingableInterface
     }
 
     /**
-     * Get the event ID
+     * Get the event ID.
      *
      * @return string
      */
     public function getEventID()
     {
-        if(!empty($this->eventID)){
+        if (!empty($this->eventID)) {
             return $this->eventID;
-        }else{
-            return \md5($this->sourceFile . $this->description . $this->expression);
         }
+
+        return \md5($this->sourceFile . $this->description . $this->expression);
     }
 
     /**

--- a/src/Event.php
+++ b/src/Event.php
@@ -902,7 +902,7 @@ class Event implements PingableInterface
      */
     public function eventID($eventID)
     {
-        if (empty($eventID)) {
+        if (!isset($eventID) || $eventID === null || $eventID === '') {
             throw new CrunzException('Event ID cannot be empty.');
         }
         if (!\is_string($eventID) && !\is_int($eventID)) {
@@ -997,7 +997,7 @@ class Event implements PingableInterface
      */
     public function getEventID()
     {
-        if (!empty($this->eventID) && \is_string($this->eventID)) {
+        if (isset($this->eventID) && $this->eventID !== null && $this->eventID !== '') {
             return $this->eventID;
         }
 

--- a/src/Task/Loader.php
+++ b/src/Task/Loader.php
@@ -9,7 +9,7 @@ use Crunz\Schedule;
 final class Loader implements LoaderInterface
 {
     /** @return Schedule[] */
-    public function load(\SplFileInfo ...$files): array
+    public function load(string $source, \SplFileInfo ...$files): array
     {
         $schedules = [];
         foreach ($files as $file) {
@@ -22,6 +22,13 @@ final class Loader implements LoaderInterface
             if (!$schedule instanceof Schedule) {
                 throw WrongTaskInstanceException::fromFilePath($file, $schedule);
             }
+
+            $events = $schedule->events();
+            foreach ($events as $event_key => $event) {
+                $events[$event_key]->sourceFile(\str_replace($source, '', $file->getRealPath()));
+            }
+
+            $schedule->events($events);
 
             $schedules[] = $schedule;
         }

--- a/src/Task/LoaderInterface.php
+++ b/src/Task/LoaderInterface.php
@@ -9,5 +9,5 @@ use Crunz\Schedule;
 interface LoaderInterface
 {
     /** @return Schedule[] */
-    public function load(\SplFileInfo ...$files): array;
+    public function load(string $source, \SplFileInfo ...$files): array;
 }

--- a/tests/TestCase/FakeLoader.php
+++ b/tests/TestCase/FakeLoader.php
@@ -14,7 +14,7 @@ final class FakeLoader implements LoaderInterface
     {
     }
 
-    public function load(\SplFileInfo ...$files): array
+    public function load(string $source, \SplFileInfo ...$files): array
     {
         return $this->schedules;
     }

--- a/tests/Unit/Console/Command/ScheduleListCommandTest.php
+++ b/tests/Unit/Console/Command/ScheduleListCommandTest.php
@@ -89,13 +89,14 @@ final class ScheduleListCommandTest extends UnitTestCase
                     'format' => 'text',
                     'schedule' => $schedule,
                     'expectedOutput' => <<<TXT
-                        +---+-------------+----------------+----------------+
-                        | # | Task        | Expression     | Command to Run |
-                        +---+-------------+----------------+----------------+
-                        | 1 | PHP version | 15 3 * * 1,3,5 | php -v         |
-                        +---+-------------+----------------+----------------+
-                        
+                        +---+-------------+----------------------------------+----------------+----------------+
+                        | # | Task        | Event ID                         | Expression     | Command to Run |
+                        +---+-------------+----------------------------------+----------------+----------------+
+                        | 1 | PHP version | 088942db8529faec5392514970a88bfa | 15 3 * * 1,3,5 | php -v         |
+                        +---+-------------+----------------------------------+----------------+----------------+
+
                         TXT,
+
                     'assert' => static function (string $expectedOutput, string $actualOutput): void {
                         self::assertSame($expectedOutput, $actualOutput);
                     },
@@ -106,6 +107,7 @@ final class ScheduleListCommandTest extends UnitTestCase
         yield 'json' => [
             function (): array {
                 $commandString = 'php -v';
+                $eventID = '088942db8529faec5392514970a88bfa';
                 $cronExpression = '15 3 * * 1,3,5';
                 $description = 'PHP version';
                 $schedule = self::createScheduleWithTask(
@@ -121,6 +123,7 @@ final class ScheduleListCommandTest extends UnitTestCase
                         [
                             [
                                 'command' => $commandString,
+                                'eventID' => $eventID,
                                 'expression' => $cronExpression,
                                 'number' => 1,
                                 'task' => $description,


### PR DESCRIPTION
In questa PR è presente una possibile soluzione che implementa il calcolo di un identificatore unico per l'evento o permette all'utente di un introdurne uno manualmente tramite apposita funzione (eventID).

This solution is linked to issue https://github.com/crunzphp/crunz/issues/33 and could be the first piece towards creating a launcher that allows you to launch a task based on the unique identifier.
