### PR TITLE
Config template - Adding logger_factory.

### DIFF
--- a/resources/config/crunz.yml
+++ b/resources/config/crunz.yml
@@ -47,6 +47,10 @@ log_allow_line_breaks: false
 # Set the value to true to remove them.
 log_ignore_empty_context: false
 
+# To use your own logger create class implementing
+# \Crunz\Application\Service\LoggerFactoryInterface then set it bellow
+logger_factory: 'Crunz\Infrastructure\Psr\Logger\PsrStreamLoggerFactory'
+
 # This option determines whether the output should be emailed or not.
 email_output: false
 


### PR DESCRIPTION
I noticed that when using the `publish:config` command the generated config file was missing the `logger_factory` setting. If that's intentional we can just close this, otherwise these changes should address that.

The default value will be the same as the one set in the service container configuration, so no behavioral changes outside the config context.