### PR TITLE
Add Symfony 8.0 Support

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -31,6 +31,7 @@ jobs:
                 symfony_version:
                     - '~6.4.0'
                     - '~7.1.0'
+                    - '~8.0'
                 include:
                     - os: 'windows-2022'
                       php: '8.1'
@@ -45,6 +46,14 @@ jobs:
                       php: '8.1'
                       dependencies: 'highest'
                       symfony_version: '~7.1.0'
+                    - os: 'ubuntu-22.04'
+                      php: '8.1'
+                      dependencies: 'lowest'
+                      symfony_version: '~8.0'
+                    - os: 'ubuntu-22.04'
+                      php: '8.1'
+                      dependencies: 'highest'
+                      symfony_version: '~8.0'
         runs-on: ${{ matrix.os }}
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -40,15 +40,15 @@
         "dragonmantank/cron-expression": "^3.4.0",
         "laravel/serializable-closure": "^2.0",
         "psr/log": "^2.0 || ^3.0",
-        "symfony/config": "^6.4.10 || ^7.1.0",
-        "symfony/console": "^6.4.10 || ^7.1.0",
-        "symfony/dependency-injection": "^6.4.10 || ^7.1.0",
-        "symfony/filesystem": "^6.4.10 || ^7.1.0",
-        "symfony/lock": "^6.4.10 || ^7.1.0",
-        "symfony/mailer": "^6.4.10 || ^7.1.0",
-        "symfony/process": "^6.4.10 || ^7.1.0",
-        "symfony/string": "^6.4.10 || ^7.1.0",
-        "symfony/yaml": "^6.4.10 || ^7.1.0"
+        "symfony/config": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/console": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/dependency-injection": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/filesystem": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/lock": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/mailer": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/process": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/string": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/yaml": "^6.4.10 || ^7.1.0 || ^8.0"
     },
     "require-dev": {
         "ext-json": "*",
@@ -59,8 +59,8 @@
         "phpstan/phpstan-phpunit": "2.0.1",
         "phpstan/phpstan-strict-rules": "2.0.0",
         "phpunit/phpunit": "10.5.38",
-        "symfony/error-handler": "^6.4.10 || ^7.1.0",
-        "symfony/phpunit-bridge": "^6.4.10 || ^7.1.0"
+        "symfony/error-handler": "^6.4.10 || ^7.1.0 || ^8.0",
+        "symfony/phpunit-bridge": "^6.4.10 || ^7.1.0 || ^8.0"
     },
     "minimum-stability": "beta",
     "prefer-stable": true,

--- a/src/Application.php
+++ b/src/Application.php
@@ -79,7 +79,7 @@ class Application extends SymfonyApplication
                 ->get($commandClass)
             ;
 
-            $this->add($command);
+            $this->addCommand($command);
         }
     }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -19,7 +19,6 @@ use Crunz\Pinger\PingableTrait;
 use Crunz\Process\Process;
 use Crunz\Task\TaskException;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
-use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\PersistingStoreInterface;


### PR DESCRIPTION
### Changes
- Updated all Symfony component version constraints in `composer.json` to include `^8.0`
- Removed unused `Factory` import from `src/Event.php`
- Fixed deprecated `add()` method call in `src/Application.php` (changed to `addCommand()`)
- Added Symfony 8.0 to CI test matrix with PHP 8.2+ requirement