### PR TITLE
Fix Symfony 7.4 deprecation warning for Application::add()

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -79,7 +79,12 @@ class Application extends SymfonyApplication
                 ->get($commandClass)
             ;
 
-            $this->add($command);
+            // @phpstan-ignore function.alreadyNarrowedType (backward compatibility with Symfony < 7.4)
+            if (\method_exists($this, 'addCommand')) {
+                $this->addCommand($command);
+            } else {
+                $this->add($command);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | N/A

Replaces deprecated `Application::add()` with `addCommand()` when available (Symfony 7.4+).

Maintains backward compatibility with Symfony 6.4 and 7.1-7.3 by using `method_exists()` check.