### PR TITLE
feat: make preventOverlapping lock TTL configurable

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -157,6 +157,7 @@ class Event implements PingableInterface
      * Indicates if the command should not overlap itself.
      */
     private bool $preventOverlapping = false;
+    private int $lockTtl = 30;
     /** @var ClockInterface */
     private static $clock;
     private static ?ClosureSerializerInterface $closureSerializer = null;
@@ -702,11 +703,14 @@ class Event implements PingableInterface
      * that will be responsible for the locking.
      *
      * @param PersistingStoreInterface|object $store
+     * @param int $lockTtl TTL in seconds for the overlap-prevention lock (default: 30)
      *
      * @return $this
      */
-    public function preventOverlapping(?object $store = null)
+    public function preventOverlapping(?object $store = null, int $lockTtl = 30)
     {
+        $this->lockTtl = $lockTtl;
+
         if (null !== $store && !($store instanceof PersistingStoreInterface)) {
             $expectedClass = PersistingStoreInterface::class;
             $actualClass = $store::class;
@@ -1101,10 +1105,8 @@ class Event implements PingableInterface
         $this->checkLockFactory();
 
         if (null === $this->lock && null !== $this->lockFactory) {
-            $ttl = 30;
-
             $this->lock = $this->lockFactory
-                ->createLock($this->lockKey(), $ttl);
+                ->createLock($this->lockKey(), $this->lockTtl);
         }
 
         return $this->lock;

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -665,6 +665,30 @@ final class EventTest extends UnitTestCase
         ];
     }
 
+    /** @test */
+    public function prevent_overlapping_default_lock_ttl_is_30(): void
+    {
+        $event = $this->createEvent();
+        $event->preventOverlapping();
+
+        $reflection = new \ReflectionProperty(Event::class, 'lockTtl');
+        $reflection->setAccessible(true);
+
+        self::assertSame(30, $reflection->getValue($event));
+    }
+
+    /** @test */
+    public function prevent_overlapping_accepts_custom_lock_ttl(): void
+    {
+        $event = $this->createEvent();
+        $event->preventOverlapping(null, 300);
+
+        $reflection = new \ReflectionProperty(Event::class, 'lockTtl');
+        $reflection->setAccessible(true);
+
+        self::assertSame(300, $reflection->getValue($event));
+    }
+
     private function assertPreventOverlapping(?PersistingStoreInterface $store = null): void
     {
         $event = $this->createPreventOverlappingEvent($store);


### PR DESCRIPTION
## Summary

- Add optional `int $lockTtl = 30` parameter to `preventOverlapping()` (backward compatible)
- Store value in new `$lockTtl` property, use it in `createLockObject()` instead of hardcoded `$ttl = 30`
- Add 2 unit tests verifying default (30s) and custom (300s) TTL behavior

Fixes #120

## Motivation

The hardcoded 30-second lock TTL combined with the probabilistic refresh mechanism (10% chance per 250ms iteration) creates a ~0.18% failure rate per lock operation when using TTL-based stores like `RedisStore`. This causes sporadic `LockConflictedException` — the lock expires before being refreshed.

Increasing the TTL (e.g. to 300s) makes the failure probability effectively zero while keeping the same refresh semantics. File-based stores (`FlockStore`) are unaffected since their locks don't expire.

## Changes

**`src/Event.php`:**
- New property: `private int $lockTtl = 30;`
- Extended signature: `preventOverlapping(?object $store = null, int $lockTtl = 30)`
- `createLockObject()` uses `$this->lockTtl` instead of hardcoded `30`

**`tests/Unit/EventTest.php`:**
- `prevent_overlapping_default_lock_ttl_is_30()` — verifies backward compatibility
- `prevent_overlapping_accepts_custom_lock_ttl()` — verifies custom TTL (300s)

## Test plan

- [x] Existing tests pass (`phpunit --filter EventTest` → 50 tests, 0 failures)
- [x] New tests pass for default and custom TTL values
- [x] Manual verification with RedisStore in production (already running with equivalent patch for weeks)