### PR TITLE
fix: limit laravel/serializable-closure to <2.0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php": ">=8.2",
         "composer-runtime-api": "^2.0",
         "dragonmantank/cron-expression": "^3.4.0",
-        "laravel/serializable-closure": "^2.0",
+        "laravel/serializable-closure": ">=2.0 <2.0.9",
         "psr/log": "^2.0 || ^3.0",
         "symfony/config": "^6.4.25 || ^7.4.0 || ^8.0.0",
         "symfony/console": "^6.4.25 || ^7.4.0 || ^8.0.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php": ">=8.2",
         "composer-runtime-api": "^2.0",
         "dragonmantank/cron-expression": "^3.4.0",
-        "laravel/serializable-closure": ">=2.0 <2.0.9",
+        "laravel/serializable-closure": "^2.0",
         "psr/log": "^2.0 || ^3.0",
         "symfony/config": "^6.4.25 || ^7.4.0 || ^8.0.0",
         "symfony/console": "^6.4.25 || ^7.4.0 || ^8.0.0",
@@ -61,6 +61,9 @@
         "phpunit/phpunit": "10.5.60",
         "symfony/error-handler": "^6.4.25 || ^7.4.0 || ^8.0.0",
         "symfony/phpunit-bridge": "^6.4.25 || ^7.4.0 || ^8.0.0"
+    },
+    "conflict": {
+        "laravel/serializable-closure": ">=2.0.9"
     },
     "minimum-stability": "beta",
     "prefer-stable": true,

--- a/tests/TestCase/SerializableTaskRunnerStub.php
+++ b/tests/TestCase/SerializableTaskRunnerStub.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\TestCase;
+
+final class SerializableTaskRunnerStub
+{
+    public string $taskName = 'daily-report';
+
+    /** @var \Closure[] */
+    public array $filters = [];
+
+    /** @return array{taskName: string, filters: array<\Closure>} */
+    public function __serialize(): array
+    {
+        return [
+            'taskName' => $this->taskName,
+            'filters' => $this->filters,
+        ];
+    }
+
+    /** @param array{taskName: string, filters: array<\Closure>} $data */
+    public function __unserialize(array $data): void
+    {
+        $this->taskName = $data['taskName'];
+        $this->filters = $data['filters'];
+    }
+
+    public function createTask(): \Closure
+    {
+        $this->filters[] = static function (): bool {
+            return true;
+        };
+
+        return function (): string {
+            return "running {$this->taskName}";
+        };
+    }
+}

--- a/tests/TestCase/TaskRunnerStub.php
+++ b/tests/TestCase/TaskRunnerStub.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\TestCase;
+
+final class TaskRunnerStub
+{
+    public string $taskName = 'daily-report';
+
+    /** @var \Closure[] */
+    public array $filters = [];
+
+    public function createTask(): \Closure
+    {
+        $this->filters[] = static function (): bool {
+            return true;
+        };
+
+        return function (): string {
+            return "running {$this->taskName}";
+        };
+    }
+}

--- a/tests/Unit/Service/LaravelClosureSerializerTest.php
+++ b/tests/Unit/Service/LaravelClosureSerializerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Crunz\Tests\Unit\Service;
 
 use Crunz\Infrastructure\Laravel\LaravelClosureSerializer;
+use Crunz\Tests\TestCase\SerializableTaskRunnerStub;
+use Crunz\Tests\TestCase\TaskRunnerStub;
 use Crunz\Tests\TestCase\UnitTestCase;
 
 final class LaravelClosureSerializerTest extends UnitTestCase
@@ -62,7 +64,7 @@ final class LaravelClosureSerializerTest extends UnitTestCase
      */
     public function test_serialize_closure_bound_to_object_with_serialize_and_closure_properties(): void
     {
-        $runner = new TaskRunnerWithSerializeStub();
+        $runner = new SerializableTaskRunnerStub();
         $closure = $runner->createTask();
 
         $serialized = $this->serializer->serialize($closure);
@@ -78,59 +80,5 @@ final class LaravelClosureSerializerTest extends UnitTestCase
         $code = $this->serializer->closureCode($testClosure);
 
         self::assertSame('static fn (): \stdClass => new \stdClass()', $code);
-    }
-}
-
-/**
- * @internal
- */
-class TaskRunnerStub
-{
-    public string $taskName = 'daily-report';
-    /** @var \Closure[] */
-    public array $filters = [];
-
-    public function createTask(): \Closure
-    {
-        $this->filters[] = static function (): bool { return true; };
-
-        return function (): string {
-            return "running {$this->taskName}";
-        };
-    }
-}
-
-/**
- * @internal
- */
-class TaskRunnerWithSerializeStub
-{
-    public string $taskName = 'daily-report';
-    /** @var \Closure[] */
-    public array $filters = [];
-
-    /** @return array{taskName: string, filters: array<\Closure>} */
-    public function __serialize(): array
-    {
-        return [
-            'taskName' => $this->taskName,
-            'filters' => $this->filters,
-        ];
-    }
-
-    /** @param array{taskName: string, filters: array<\Closure>} $data */
-    public function __unserialize(array $data): void
-    {
-        $this->taskName = $data['taskName'];
-        $this->filters = $data['filters'];
-    }
-
-    public function createTask(): \Closure
-    {
-        $this->filters[] = static function (): bool { return true; };
-
-        return function (): string {
-            return "running {$this->taskName}";
-        };
     }
 }

--- a/tests/Unit/Service/LaravelClosureSerializerTest.php
+++ b/tests/Unit/Service/LaravelClosureSerializerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\Unit\Service;
+
+use Crunz\Infrastructure\Laravel\LaravelClosureSerializer;
+use Crunz\Tests\TestCase\UnitTestCase;
+
+final class LaravelClosureSerializerTest extends UnitTestCase
+{
+    private LaravelClosureSerializer $serializer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = new LaravelClosureSerializer();
+    }
+
+    public function test_serialize_simple_closure(): void
+    {
+        $closure = static function (): string {
+            return 'hello';
+        };
+
+        $serialized = $this->serializer->serialize($closure);
+        $result = $this->serializer->unserialize($serialized);
+
+        self::assertSame('hello', $result());
+    }
+
+    public function test_serialize_closure_with_use_variable(): void
+    {
+        $name = 'crunz';
+        $closure = static function () use ($name): string {
+            return "hello {$name}";
+        };
+
+        $serialized = $this->serializer->serialize($closure);
+        $result = $this->serializer->unserialize($serialized);
+
+        self::assertSame('hello crunz', $result());
+    }
+
+    public function test_serialize_closure_bound_to_object_with_closure_properties(): void
+    {
+        $runner = new TaskRunnerStub();
+        $closure = $runner->createTask();
+
+        $serialized = $this->serializer->serialize($closure);
+        $result = $this->serializer->unserialize($serialized);
+
+        self::assertSame('running daily-report', $result());
+    }
+
+    /**
+     * Regression test for laravel/serializable-closure#126.
+     *
+     * v2.0.9 skips walking properties of objects that implement __serialize,
+     * leaving nested closures unwrapped and causing "Serialization of 'Closure'
+     * is not allowed".
+     */
+    public function test_serialize_closure_bound_to_object_with_serialize_and_closure_properties(): void
+    {
+        $runner = new TaskRunnerWithSerializeStub();
+        $closure = $runner->createTask();
+
+        $serialized = $this->serializer->serialize($closure);
+        $result = $this->serializer->unserialize($serialized);
+
+        self::assertSame('running daily-report', $result());
+    }
+
+    public function test_closure_code_can_be_extracted(): void
+    {
+        $testClosure = static fn (): \stdClass => new \stdClass();
+
+        $code = $this->serializer->closureCode($testClosure);
+
+        self::assertSame('static fn (): \stdClass => new \stdClass()', $code);
+    }
+}
+
+/**
+ * @internal
+ */
+class TaskRunnerStub
+{
+    public string $taskName = 'daily-report';
+    /** @var \Closure[] */
+    public array $filters = [];
+
+    public function createTask(): \Closure
+    {
+        $this->filters[] = static function (): bool { return true; };
+
+        return function (): string {
+            return "running {$this->taskName}";
+        };
+    }
+}
+
+/**
+ * @internal
+ */
+class TaskRunnerWithSerializeStub
+{
+    public string $taskName = 'daily-report';
+    /** @var \Closure[] */
+    public array $filters = [];
+
+    /** @return array{taskName: string, filters: array<\Closure>} */
+    public function __serialize(): array
+    {
+        return [
+            'taskName' => $this->taskName,
+            'filters' => $this->filters,
+        ];
+    }
+
+    /** @param array{taskName: string, filters: array<\Closure>} $data */
+    public function __unserialize(array $data): void
+    {
+        $this->taskName = $data['taskName'];
+        $this->filters = $data['filters'];
+    }
+
+    public function createTask(): \Closure
+    {
+        $this->filters[] = static function (): bool { return true; };
+
+        return function (): string {
+            return "running {$this->taskName}";
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Constrains `laravel/serializable-closure` to `>=2.0 <2.0.9` in `composer.json` to avoid a breaking change introduced in v2.0.9

## Problem

`laravel/serializable-closure` v2.0.9 introduced a regression ([laravel/serializable-closure#122](https://github.com/laravel/serializable-closure/pull/122)) that modifies `Native::wrapClosures()` and `Native::mapByReference()` to skip walking object properties when the object implements `__serialize`. This prevents the library from finding and wrapping closures nested inside those objects, causing:

```
[Exception]
Serialization of 'Closure' is not allowed
```

I verified this across all available versions:

| Version | Result |
|---------|--------|
| v2.0.8 | ✅ Works |
| v2.0.9 | ❌ Broken |
| v2.0.10 | ❌ Broken |
| 2.x-dev | ❌ Still broken |

The upstream issue has been reported: **laravel/serializable-closure#126**

## Fix

Constrains the `laravel/serializable-closure` dependency to `>=2.0 <2.0.9` until the upstream regression is resolved.

Fixes #122