### PR TITLE
Fix weekday constraints when chaining every* methods

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -1250,18 +1250,23 @@ class Event implements PingableInterface
      * Preserve day-of-week constraints while applying every* frequency shortcuts.
      *
      * @param string $expression
+     *
+     * @return self
      */
-    protected function cronPreservingCurrentDayOfWeek($expression): self
+    protected function cronPreservingCurrentDayOfWeek(string $expression): self
     {
-        $currentExpressionParts = \explode(' ', $this->expression);
-        $newExpressionParts = \explode(' ', $expression);
+        $weekdayPosition = $this->fieldsPosition['week'] - 1;
+        $currentExpressionParts = \preg_split('/\s+/', $this->expression, -1, PREG_SPLIT_NO_EMPTY);
+        $newExpressionParts = \preg_split('/\s+/', $expression, -1, PREG_SPLIT_NO_EMPTY);
+        $currentExpressionParts = false === $currentExpressionParts ? [] : $currentExpressionParts;
+        $newExpressionParts = false === $newExpressionParts ? [] : $newExpressionParts;
 
         if (
-            isset($currentExpressionParts[4], $newExpressionParts[4])
-            && '*' !== $currentExpressionParts[4]
-            && '*' === $newExpressionParts[4]
+            isset($currentExpressionParts[$weekdayPosition], $newExpressionParts[$weekdayPosition])
+            && '*' !== $currentExpressionParts[$weekdayPosition]
+            && '*' === $newExpressionParts[$weekdayPosition]
         ) {
-            $newExpressionParts[4] = $currentExpressionParts[4];
+            $newExpressionParts[$weekdayPosition] = $currentExpressionParts[$weekdayPosition];
         }
 
         return $this->cron(\implode(' ', $newExpressionParts));

--- a/src/Event.php
+++ b/src/Event.php
@@ -1248,10 +1248,6 @@ class Event implements PingableInterface
 
     /**
      * Preserve day-of-week constraints while applying every* frequency shortcuts.
-     *
-     * @param string $expression
-     *
-     * @return self
      */
     protected function cronPreservingCurrentDayOfWeek(string $expression): self
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -1033,62 +1033,62 @@ class Event implements PingableInterface
 
     public function everyMinute(): self
     {
-        return $this->cron('* * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('* * * * *');
     }
 
     public function everyTwoMinutes(): self
     {
-        return $this->cron('*/2 * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('*/2 * * * *');
     }
 
     public function everyThreeMinutes(): self
     {
-        return $this->cron('*/3 * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('*/3 * * * *');
     }
 
     public function everyFourMinutes(): self
     {
-        return $this->cron('*/4 * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('*/4 * * * *');
     }
 
     public function everyFiveMinutes(): self
     {
-        return $this->cron('*/5 * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('*/5 * * * *');
     }
 
     public function everyTenMinutes(): self
     {
-        return $this->cron('*/10 * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('*/10 * * * *');
     }
 
     public function everyFifteenMinutes(): self
     {
-        return $this->cron('*/15 * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('*/15 * * * *');
     }
 
     public function everyThirtyMinutes(): self
     {
-        return $this->cron('*/30 * * * *');
+        return $this->cronPreservingCurrentDayOfWeek('*/30 * * * *');
     }
 
     public function everyTwoHours(): self
     {
-        return $this->cron('0 */2 * * *');
+        return $this->cronPreservingCurrentDayOfWeek('0 */2 * * *');
     }
 
     public function everyThreeHours(): self
     {
-        return $this->cron('0 */3 * * *');
+        return $this->cronPreservingCurrentDayOfWeek('0 */3 * * *');
     }
 
     public function everyFourHours(): self
     {
-        return $this->cron('0 */4 * * *');
+        return $this->cronPreservingCurrentDayOfWeek('0 */4 * * *');
     }
 
     public function everySixHours(): self
     {
-        return $this->cron('0 */6 * * *');
+        return $this->cronPreservingCurrentDayOfWeek('0 */6 * * *');
     }
 
     /**
@@ -1244,6 +1244,27 @@ class Event implements PingableInterface
         \array_splice($cron, 0, $fpos, \array_slice($mask, 0, $fpos));
 
         return $this->cron(\implode(' ', $cron));
+    }
+
+    /**
+     * Preserve day-of-week constraints while applying every* frequency shortcuts.
+     *
+     * @param string $expression
+     */
+    protected function cronPreservingCurrentDayOfWeek($expression): self
+    {
+        $currentExpressionParts = \explode(' ', $this->expression);
+        $newExpressionParts = \explode(' ', $expression);
+
+        if (
+            isset($currentExpressionParts[4], $newExpressionParts[4])
+            && '*' !== $currentExpressionParts[4]
+            && '*' === $newExpressionParts[4]
+        ) {
+            $newExpressionParts[4] = $currentExpressionParts[4];
+        }
+
+        return $this->cron(\implode(' ', $newExpressionParts));
     }
 
     /**

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -434,6 +434,44 @@ final class EventTest extends UnitTestCase
         self::assertSame($expectedCronExpression, $event->getExpression());
     }
 
+    /** @dataProvider everyMethodProvider */
+    public function test_every_methods_keep_weekday_constraint(string $method, string $expectedCronExpression): void
+    {
+        // Arrange
+        $event = new Event($this->id, 'php -i');
+        $event->mondays();
+        /** @var callable $methodCall */
+        $methodCall = [$event, $method];
+        $methodCallClosure = \Closure::fromCallable($methodCall);
+
+        $expressionParts = \explode(' ', $expectedCronExpression);
+        $expressionParts[4] = '1';
+        $expectedExpression = \implode(' ', $expressionParts);
+
+        // Act
+        $methodCallClosure();
+
+        // Assert
+        self::assertSame($expectedExpression, $event->getExpression());
+    }
+
+    public function test_between_and_weekday_can_be_chained_with_every_five_minutes(): void
+    {
+        // Arrange
+        $event = new Event($this->id, 'php -i');
+
+        // Act
+        $event
+            ->mondays()
+            ->everyFiveMinutes()
+            ->between('08:00', '17:00');
+
+        // Assert
+        self::assertSame('*/5 * * * 1', $event->getExpression());
+        self::assertSame('08:00', $event->getFrom());
+        self::assertSame('17:00', $event->getTo());
+    }
+
     public function test_hourly_at_with_valid_minute(): void
     {
         // Arrange

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -455,23 +455,6 @@ final class EventTest extends UnitTestCase
         self::assertSame($expectedExpression, $event->getExpression());
     }
 
-    public function test_between_and_weekday_can_be_chained_with_every_five_minutes(): void
-    {
-        // Arrange
-        $event = new Event($this->id, 'php -i');
-
-        // Act
-        $event
-            ->mondays()
-            ->everyFiveMinutes()
-            ->between('08:00', '17:00');
-
-        // Assert
-        self::assertSame('*/5 * * * 1', $event->getExpression());
-        self::assertSame('08:00', $event->getFrom());
-        self::assertSame('17:00', $event->getTo());
-    }
-
     public function test_hourly_at_with_valid_minute(): void
     {
         // Arrange

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -445,7 +445,30 @@ final class EventTest extends UnitTestCase
         $methodCallClosure = \Closure::fromCallable($methodCall);
 
         $expressionParts = \explode(' ', $expectedCronExpression);
-        $expressionParts[4] = '1';
+        $dayOfWeekPosition = \count($expressionParts) - 1;
+        $expressionParts[$dayOfWeekPosition] = '1';
+        $expectedExpression = \implode(' ', $expressionParts);
+
+        // Act
+        $methodCallClosure();
+
+        // Assert
+        self::assertSame($expectedExpression, $event->getExpression());
+    }
+
+    /** @dataProvider everyMethodProvider */
+    public function test_every_methods_keep_comma_separated_weekday_constraint(string $method, string $expectedCronExpression): void
+    {
+        // Arrange
+        $event = new Event($this->id, 'php -i');
+        $event->days(1, 3);
+        /** @var callable $methodCall */
+        $methodCall = [$event, $method];
+        $methodCallClosure = \Closure::fromCallable($methodCall);
+
+        $expressionParts = \explode(' ', $expectedCronExpression);
+        $dayOfWeekPosition = \count($expressionParts) - 1;
+        $expressionParts[$dayOfWeekPosition] = '1,3';
         $expectedExpression = \implode(' ', $expressionParts);
 
         // Act


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #105

Calling weekday helpers before `every*` methods currently resets day-of-week to `*`, so chains like:

`$task->mondays()->everyFiveMinutes()->between('08:00', '17:00')`

lose the weekday constraint.

The `every*` methods now preserve the current day-of-week segment when applying expressions with wildcard weekday, so weekday + `between()` chains work correctly regardless of call order.

Adds unit coverage to ensure all `every*` helpers keep an existing weekday constraint.