### PR TITLE
Quote PHP_BINARY and CRUNZ_BIN in closure shell commands

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -1156,7 +1156,7 @@ class Event implements PingableInterface
         $serializedClosure = \http_build_query([$closure]);
         $crunzRoot = CRUNZ_BIN;
 
-        return PHP_BINARY . " {$crunzRoot} closure:run {$serializedClosure}";
+        return \escapeshellarg(PHP_BINARY) . ' ' . \escapeshellarg($crunzRoot) . " closure:run {$serializedClosure}";
     }
 
     /**

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -373,7 +373,7 @@ final class EventTest extends UnitTestCase
 
         $command = $event->buildCommand();
 
-        self::assertSame(PHP_BINARY . " {$crunzBin} closure:run {$queryClosure}", $command);
+        self::assertSame(\escapeshellarg(PHP_BINARY) . ' ' . \escapeshellarg($crunzBin) . " closure:run {$queryClosure}", $command);
     }
 
     /** @test */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #109

On Windows, when PHP is installed under a path that contains spaces (e.g.
`C:\Program Files\PHP\php.exe`), closure-based tasks fail silently.
`serializeClosure()` in `Event.php` concatenates `PHP_BINARY` and `CRUNZ_BIN`
directly into the shell command string without quoting, so the OS splits the
path at the first space and tries to execute a truncated binary name.

Both values are now wrapped with `escapeshellarg()`, which adds the appropriate
quoting on every platform. The existing `serializeClosure` test is updated to
expect the quoted form.