### PR TITLE
fix: narrow serializable-closure conflict to only broken versions (2.0.9–2.0.10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "symfony/phpunit-bridge": "^6.4.25 || ^7.4.0 || ^8.0.0"
     },
     "conflict": {
-        "laravel/serializable-closure": ">=2.0.9"
+        "laravel/serializable-closure": ">=2.0.9, <2.0.11"
     },
     "minimum-stability": "beta",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "symfony/phpunit-bridge": "^6.4.25 || ^7.4.0 || ^8.0.0"
     },
     "conflict": {
-        "laravel/serializable-closure": ">=2.0.9, <2.0.11"
+        "laravel/serializable-closure": ">=2.0.9,<2.0.11"
     },
     "minimum-stability": "beta",
     "prefer-stable": true,


### PR DESCRIPTION
## Summary

- Narrows the `laravel/serializable-closure` conflict from `>=2.0.9` to `>=2.0.9, <2.0.11`, allowing v2.0.11+ which includes the upstream fix

## Context

PR #123 added a `conflict` entry blocking `>=2.0.9` due to a regression in `laravel/serializable-closure` ([laravel/serializable-closure#126](https://github.com/laravel/serializable-closure/issues/126)). That regression was fixed upstream in [laravel/serializable-closure#129](https://github.com/laravel/serializable-closure/pull/129), which shipped in **v2.0.11**.

The current blanket `>=2.0.9` constraint blocks the fixed version too. This PR narrows it to only the two broken releases:

| Version | Status |
|---------|--------|
| v2.0.8 | ✅ Works |
| v2.0.9 | ❌ Broken |
| v2.0.10 | ❌ Broken |
| v2.0.11 | ✅ Fixed ([#129](https://github.com/laravel/serializable-closure/pull/129)) |

Follow-up to #123.