### PR TITLE
Add flag to return non-zero code when any task fails

### DIFF
--- a/src/Console/Command/ScheduleRunCommand.php
+++ b/src/Console/Command/ScheduleRunCommand.php
@@ -61,7 +61,13 @@ class ScheduleRunCommand extends Command
                 'Which task to run. Provide task number from <info>schedule:list</info> command.',
                 null
             )
-           ->setHelp('This command starts the Crunz event runner.');
+            ->addOption(
+                'fail-on-task-error',
+                null,
+                InputOption::VALUE_NONE,
+                'Return a non-zero code if any task fails.',
+            )
+            ->setHelp('This command starts the Crunz event runner.');
     }
 
     /**
@@ -126,11 +132,22 @@ class ScheduleRunCommand extends Command
             return 0;
         }
 
+        $returnCode = 0;
+
+        $failOnTaskError = \filter_var($this->options['fail-on-task-error'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        if ($failOnTaskError) {
+            foreach ($schedules as $schedule) {
+                $schedule->onError(static function () use (&$returnCode): void {
+                    $returnCode = 1;
+                });
+            }
+        }
+
         // Running the events
         $this->eventRunner
             ->handle($output, $schedules)
         ;
 
-        return 0;
+        return $returnCode;
     }
 }

--- a/tests/EndToEnd/FailOnTaskErrorTest.php
+++ b/tests/EndToEnd/FailOnTaskErrorTest.php
@@ -21,7 +21,7 @@ final class FailOnTaskErrorTest extends EndToEndTestCase
 
         $process = $environment->runCrunzCommand('schedule:run --force');
 
-        $this->assertTrue($process->isSuccessful(), 'Should be successful even if task fails when flag is not present.');
+        self::assertTrue($process->isSuccessful(), 'Should be successful even if task fails when flag is not present.');
     }
 
     /** @test */
@@ -37,7 +37,7 @@ final class FailOnTaskErrorTest extends EndToEndTestCase
 
         $process = $environment->runCrunzCommand('schedule:run --force --fail-on-task-error');
 
-        $this->assertFalse($process->isSuccessful(), 'Should not be successful when closure task fails and flag is present.');
+        self::assertFalse($process->isSuccessful(), 'Should not be successful when closure task fails and flag is present.');
     }
 
     /** @test */
@@ -53,6 +53,6 @@ final class FailOnTaskErrorTest extends EndToEndTestCase
 
         $process = $environment->runCrunzCommand('schedule:run --force --fail-on-task-error');
 
-        $this->assertFalse($process->isSuccessful(), 'Should not be successful when command task fails and flag is present.');
+        self::assertFalse($process->isSuccessful(), 'Should not be successful when command task fails and flag is present.');
     }
 }

--- a/tests/EndToEnd/FailOnTaskErrorTest.php
+++ b/tests/EndToEnd/FailOnTaskErrorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\EndToEnd;
+
+use Crunz\Tests\TestCase\EndToEndTestCase;
+
+final class FailOnTaskErrorTest extends EndToEndTestCase
+{
+    /** @test */
+    public function test_success_return_code_when_task_fails_and_flag_is_not_present(): void
+    {
+        $envBuilder = $this->createEnvironmentBuilder();
+        $envBuilder
+            ->addTask('FailTasks')
+            ->withConfig(['timezone' => 'UTC'])
+        ;
+
+        $environment = $envBuilder->createEnvironment();
+
+        $process = $environment->runCrunzCommand('schedule:run --force');
+
+        $this->assertTrue($process->isSuccessful(), 'Should be successful even if task fails when flag is not present.');
+    }
+
+    /** @test */
+    public function test_not_successful_return_code_when_closure_task_fails_and_flag_is_present(): void
+    {
+        $envBuilder = $this->createEnvironmentBuilder();
+        $envBuilder
+            ->addTask('FailTasks')
+            ->withConfig(['timezone' => 'UTC'])
+        ;
+
+        $environment = $envBuilder->createEnvironment();
+
+        $process = $environment->runCrunzCommand('schedule:run --force --fail-on-task-error');
+
+        $this->assertFalse($process->isSuccessful(), 'Should not be successful when closure task fails and flag is present.');
+    }
+
+    /** @test */
+    public function test_not_successful_return_code_when_command_task_fails_and_flag_is_present(): void
+    {
+        $envBuilder = $this->createEnvironmentBuilder();
+        $envBuilder
+            ->addTask('FailExitCodeTasks')
+            ->withConfig(['timezone' => 'UTC'])
+        ;
+
+        $environment = $envBuilder->createEnvironment();
+
+        $process = $environment->runCrunzCommand('schedule:run --force --fail-on-task-error');
+
+        $this->assertFalse($process->isSuccessful(), 'Should not be successful when command task fails and flag is present.');
+    }
+}

--- a/tests/resources/tasks/FailExitCodeTasks.php
+++ b/tests/resources/tasks/FailExitCodeTasks.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Crunz\Schedule;
+
+$scheduler = new Schedule();
+$scheduler
+    ->run('php -r "exit(1);"')
+    ->description('Task that will fail with exit code 1')
+    ->everyMinute()
+;
+
+return $scheduler;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | N/A

This introduces a new flag `--fail-on-task-error` to the command `schedule:run`. When this flag is present (default is false) and any task fails, the command will also return a non-zero code.

This can be used for better observability, as it allows to monitor the return code of the command and be notified whenever any task fails.