### PR TITLE
feat: add output_realtime to stream task output as produced (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- [crunzphp#83] Add `output_realtime` config option to stream task output to the console as it is produced instead of only after the task finishes
+- [crunzphp#83] Add `output_realtime` config option to stream task output to its destination (log file or console) as it is produced instead of only after the task finishes
 
 ## [v3.7.0] - 2024-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- [crunzphp#83] Add `output_realtime` config option to stream task output to the console as it is produced instead of only after the task finishes
+
 ## [v3.7.0] - 2024-08-12
 
 ### Changed
@@ -556,6 +560,7 @@ In `v2` this will result in exception.
 [crunzphp#77]: https://github.com/crunzphp/crunz/pull/77
 [crunzphp#78]: https://github.com/crunzphp/crunz/pull/78
 [crunzphp#79]: https://github.com/crunzphp/crunz/pull/79
+[crunzphp#83]: https://github.com/crunzphp/crunz/issues/83
 [v1.5.1]: https://github.com/crunzphp/crunz/compare/v1.5.0...v1.5.1
 [v1.6.0]: https://github.com/crunzphp/crunz/compare/v1.5.1...v1.6.0
 [v1.6.1]: https://github.com/crunzphp/crunz/compare/v1.6.0...v1.6.1

--- a/README.md
+++ b/README.md
@@ -555,6 +555,38 @@ Method `appendOutputTo()` **appends** the output to the specified file. To overr
 
 It is also possible to send the errors as emails to a group of recipients by setting `email_output` and `mailer` settings in the configuration file.
 
+## Realtime Output
+
+By default a task's output is buffered and only emitted once the task has
+finished. For long-running tasks (for example a worker that polls a queue in a
+loop) this means no output is visible until the task ends, which makes
+monitoring and debugging difficult, especially when logs are collected from
+the process' standard output (e.g. Docker/CloudWatch).
+
+Setting `output_realtime` to `true` streams each task's output to the console
+as soon as it is produced: standard output is written to `stdout` and error
+output to `stderr`.
+
+```yaml
+# Configuration settings
+
+## ...
+output_realtime: true
+## ...
+```
+
+In realtime mode the successful output is streamed live instead of being
+written again after the task finishes, so it is not duplicated. Output is
+forwarded verbatim (it is not passed through the console formatter). Error
+reporting (`log_errors`/`email_errors`) and `email_output` are unaffected and
+still operate on the complete output once the task completes.
+
+> Note: realtime mode streams successful output to the process' `stdout`/`stderr`.
+> When it is enabled, the successful-output log record (`log_output` /
+> `output_log_file` and per-event `sendOutputTo()`/`appendOutputTo()`) is
+> replaced by the live stream and is therefore not written at the end of the
+> job. The error log and email outputs are not affected.
+
 ## Error Handling
 
 Crunz makes error handling easy by logging and also allowing you add a set of callbacks in case of an error.
@@ -860,6 +892,12 @@ errors_log_file:
 # null output.
 # Set this to true if you want to keep the outputs
 log_output: false
+
+# By default a task's output is buffered and only emitted once the task
+# finishes. Set this to true to stream the output to the console (stdout for
+# standard output, stderr for error output) as soon as it is produced. Useful
+# for long-running tasks whose logs would otherwise be invisible until they end.
+output_realtime: false
 
 # This is the absolute path to the global output log file
 # The events which have dedicated log files (defined with them), won't be

--- a/README.md
+++ b/README.md
@@ -563,10 +563,9 @@ loop) this means no output is visible until the task ends, which makes
 monitoring and debugging difficult, especially when logs are collected from
 the process' standard output (e.g. Docker/CloudWatch).
 
-Setting `output_realtime` to `true` streams each task's output to the console
-as soon as it is produced: standard output is written to `stdout` and error
-output to `stderr`. Output is forwarded verbatim (it is not passed through the
-console formatter).
+Setting `output_realtime` to `true` streams each task's output to its
+configured destination as soon as it is produced, instead of buffering it until
+the task finishes:
 
 ```yaml
 # Configuration settings
@@ -576,31 +575,37 @@ output_realtime: true
 ## ...
 ```
 
-Realtime streaming is **additive**: every other sink keeps working exactly as
-before. The only thing realtime mode changes is that it does **not** also print
-the output to the console a second time at the end of the job (which would
-duplicate the live stream). Concretely:
+The output is streamed to the same destination it would normally be written to
+at the end of the job, resolved in the usual order:
 
-- **Log files** (`log_output` → `output_log_file`, and per-event
-  `sendOutputTo()`/`appendOutputTo()`) are still written at the end of the job.
-- **`email_output`** and the **error reporting** sinks (`log_errors`,
-  `email_errors`) are unaffected and still operate on the complete output.
-- The end-of-job emission that prints output **directly to the console** is
-  suppressed (since that output already streamed live).
+1. a per-event log file, if the task uses `sendOutputTo()`/`appendOutputTo()`;
+2. otherwise the global `output_log_file`, if `log_output` is enabled;
+3. otherwise the console (`stdout` for standard output, `stderr` for errors).
 
-> Note: if a log destination is itself the console stream — i.e. you set
-> `output_log_file` (or `errors_log_file`) to `php://stdout` / `php://stderr` —
-> then the live stream and the end-of-job log record both target the same
-> stream, so the output appears twice. When you enable `output_realtime`, set
-> `log_output: false` (and `log_errors: false`) if those logs were only going to
-> stdout/stderr: the realtime stream already provides them. Point them at a real
-> file instead if you want a persisted copy.
+So a task logging to a file gets that file written **live** (line by line as it
+runs), and a task whose output goes to `stdout` (e.g. for Docker/CloudWatch)
+gets it streamed to `stdout` live. The output is forwarded **verbatim** — the
+live stream is the raw task output, not the framed `[date] crunz.INFO: ...`
+record that buffered mode writes. Because the destination receives the live
+stream, the end-of-job framed record to that same destination is not written
+again (it would duplicate the stream).
+
+`email_output` is unaffected: it still sends the complete output once the task
+finishes. The error reporting sinks (`log_errors` → `errors_log_file`,
+`email_errors`) are also unaffected.
+
+> Notes:
 >
-> Realtime mode changes **when and where** output is shown, not how much is held
-> in memory: the output is still buffered internally so `email_output` can send
-> the complete output at the end. Output echoed by `before()`/`then()` callbacks
-> is included in the log/email sinks but is not part of the live console stream
-> (only the task process' own output is streamed).
+> - Realtime mode changes **when and in what form** output is written, not how
+>   much is held in memory: the output is still buffered internally so
+>   `email_output` can send the complete output at the end.
+> - Only the task process' own output is streamed. Output echoed by
+>   `before()`/`then()` callbacks is still sent via `email_output` but is not
+>   part of the live stream.
+> - If two sinks resolve to the same underlying stream — for example
+>   `output_log_file: php://stdout` together with a separate consumer of the
+>   runner's stdout — the output can appear twice on that stream. Point the log
+>   at a real file, or disable it, when you rely on the live stream.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -565,7 +565,8 @@ the process' standard output (e.g. Docker/CloudWatch).
 
 Setting `output_realtime` to `true` streams each task's output to the console
 as soon as it is produced: standard output is written to `stdout` and error
-output to `stderr`.
+output to `stderr`. Output is forwarded verbatim (it is not passed through the
+console formatter).
 
 ```yaml
 # Configuration settings
@@ -575,17 +576,31 @@ output_realtime: true
 ## ...
 ```
 
-In realtime mode the successful output is streamed live instead of being
-written again after the task finishes, so it is not duplicated. Output is
-forwarded verbatim (it is not passed through the console formatter). Error
-reporting (`log_errors`/`email_errors`) and `email_output` are unaffected and
-still operate on the complete output once the task completes.
+Realtime streaming is **additive**: every other sink keeps working exactly as
+before. The only thing realtime mode changes is that it does **not** also print
+the output to the console a second time at the end of the job (which would
+duplicate the live stream). Concretely:
 
-> Note: realtime mode streams successful output to the process' `stdout`/`stderr`.
-> When it is enabled, the successful-output log record (`log_output` /
-> `output_log_file` and per-event `sendOutputTo()`/`appendOutputTo()`) is
-> replaced by the live stream and is therefore not written at the end of the
-> job. The error log and email outputs are not affected.
+- **Log files** (`log_output` → `output_log_file`, and per-event
+  `sendOutputTo()`/`appendOutputTo()`) are still written at the end of the job.
+- **`email_output`** and the **error reporting** sinks (`log_errors`,
+  `email_errors`) are unaffected and still operate on the complete output.
+- The end-of-job emission that prints output **directly to the console** is
+  suppressed (since that output already streamed live).
+
+> Note: if a log destination is itself the console stream — i.e. you set
+> `output_log_file` (or `errors_log_file`) to `php://stdout` / `php://stderr` —
+> then the live stream and the end-of-job log record both target the same
+> stream, so the output appears twice. When you enable `output_realtime`, set
+> `log_output: false` (and `log_errors: false`) if those logs were only going to
+> stdout/stderr: the realtime stream already provides them. Point them at a real
+> file instead if you want a persisted copy.
+>
+> Realtime mode changes **when and where** output is shown, not how much is held
+> in memory: the output is still buffered internally so `email_output` can send
+> the complete output at the end. Output echoed by `before()`/`then()` callbacks
+> is included in the log/email sinks but is not part of the live console stream
+> (only the task process' own output is streamed).
 
 ## Error Handling
 

--- a/resources/config/crunz.yml
+++ b/resources/config/crunz.yml
@@ -35,15 +35,15 @@ errors_log_file: ~
 log_output: false
 
 # By default a task's output is buffered and only emitted once the task
-# finishes. Set this to true to stream the output to the console (stdout for
-# standard output, stderr for error output) as soon as it is produced. This is
-# useful for long-running tasks whose logs would otherwise be invisible until
-# completion (e.g. when monitored via Docker/CloudWatch). Realtime streaming is
-# additive: log files (log_output / sendOutputTo), email_output and error
-# reporting all keep working; only the end-of-job emission that prints directly
-# to the console is suppressed (it would duplicate the live stream). If a log
-# destination is itself php://stdout/php://stderr, set log_output/log_errors to
-# false when enabling this so the same output is not printed twice.
+# finishes. Set this to true to stream the output to its destination as soon as
+# it is produced, instead of buffering it. The output is streamed to wherever it
+# would normally be written: a per-event log file (sendOutputTo), else the
+# global output_log_file (when log_output is true), else the console (stdout for
+# standard output, stderr for errors). The live stream is the raw task output
+# (not the framed "[date] crunz.INFO:" record), and it replaces the end-of-job
+# record for that destination. email_output and error reporting are unaffected.
+# Useful for long-running tasks whose logs would otherwise be invisible until
+# completion (e.g. when monitored via Docker/CloudWatch).
 output_realtime: false
 
 # This is the absolute path to the global output log file

--- a/resources/config/crunz.yml
+++ b/resources/config/crunz.yml
@@ -38,10 +38,12 @@ log_output: false
 # finishes. Set this to true to stream the output to the console (stdout for
 # standard output, stderr for error output) as soon as it is produced. This is
 # useful for long-running tasks whose logs would otherwise be invisible until
-# completion (e.g. when monitored via Docker/CloudWatch). In realtime mode the
-# successful output is streamed live instead of being written again at the end
-# of the job, so it is not duplicated; error reporting and email_output are
-# unaffected.
+# completion (e.g. when monitored via Docker/CloudWatch). Realtime streaming is
+# additive: log files (log_output / sendOutputTo), email_output and error
+# reporting all keep working; only the end-of-job emission that prints directly
+# to the console is suppressed (it would duplicate the live stream). If a log
+# destination is itself php://stdout/php://stderr, set log_output/log_errors to
+# false when enabling this so the same output is not printed twice.
 output_realtime: false
 
 # This is the absolute path to the global output log file

--- a/resources/config/crunz.yml
+++ b/resources/config/crunz.yml
@@ -34,6 +34,16 @@ errors_log_file: ~
 # Set this to true if you want to keep the outputs
 log_output: false
 
+# By default a task's output is buffered and only emitted once the task
+# finishes. Set this to true to stream the output to the console (stdout for
+# standard output, stderr for error output) as soon as it is produced. This is
+# useful for long-running tasks whose logs would otherwise be invisible until
+# completion (e.g. when monitored via Docker/CloudWatch). In realtime mode the
+# successful output is streamed live instead of being written again at the end
+# of the job, so it is not duplicated; error reporting and email_output are
+# unaffected.
+output_realtime: false
+
 # This is the absolute path to the global output log file
 # The events which have dedicated log files (defined with them), won't be
 # logged to this file though.

--- a/src/Configuration/Definition.php
+++ b/src/Configuration/Definition.php
@@ -59,6 +59,14 @@ class Definition implements ConfigurationInterface
                     ->info('Flag for logging output' . PHP_EOL)
                 ->end()
 
+                ->booleanNode('output_realtime')
+                    ->defaultFalse()
+                    ->info(
+                        'Stream task output to the console as it is produced'
+                        . ' instead of only after the task finishes.' . PHP_EOL
+                    )
+                ->end()
+
                 ->scalarNode('output_log_file')
                     ->defaultValue('/dev/null')
                     ->info('Path to output logs' . PHP_EOL)

--- a/src/Event.php
+++ b/src/Event.php
@@ -171,6 +171,13 @@ class Event implements PingableInterface
     private ?LockFactory $lockFactory = null;
     /** @var string[] */
     private array $wholeOutput = [];
+    /**
+     * Optional sink invoked with each output chunk as it is produced, used to
+     * stream output in realtime instead of only after the process exits.
+     *
+     * @var \Closure(string, string):void|null
+     */
+    private ?\Closure $realtimeCallback = null;
     /** @var Lock */
     private $lock;
     /** @var \Closure[] */
@@ -296,6 +303,20 @@ class Event implements PingableInterface
     }
 
     /**
+     * Register a sink that receives each output chunk as it is produced.
+     *
+     * The sink is invoked from the process output callback with the Symfony
+     * Process output type ('out'/'err') and the chunk content, enabling
+     * realtime streaming of output while it is still being generated.
+     *
+     * @param \Closure(string, string):void|null $callback
+     */
+    public function setRealtimeCallback(?\Closure $callback): void
+    {
+        $this->realtimeCallback = $callback;
+    }
+
+    /**
      * Start the event execution.
      *
      * @return int
@@ -309,6 +330,10 @@ class Event implements PingableInterface
         $this->getProcess()->start(
             function ($type, $content): void {
                 $this->wholeOutput[] = $content;
+
+                if (null !== $this->realtimeCallback) {
+                    ($this->realtimeCallback)($type, $content);
+                }
             }
         );
 

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -10,7 +10,9 @@ use Crunz\Logger\ConsoleLoggerInterface;
 use Crunz\Logger\Logger;
 use Crunz\Logger\LoggerFactory;
 use Crunz\Pinger\PingableInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process as SymfonyProcess;
 
 class EventRunner
 {
@@ -73,6 +75,12 @@ class EventRunner
             }
             // Create an instance of the Logger specific to the event
             $event->logger = $this->loggerFactory->createEvent($event->output);
+        }
+
+        // When realtime output is enabled, stream the task's output to the
+        // console as it is produced instead of only after the process exits.
+        if ($this->realtimeOutputEnabled()) {
+            $event->setRealtimeCallback($this->createRealtimeCallback());
         }
 
         $this->consoleLogger
@@ -174,6 +182,17 @@ class EventRunner
 
     protected function handleOutput(Event $event): void
     {
+        // In realtime mode the task's successful output has already been
+        // streamed live to the console, so the end-of-job emission (per-event
+        // log, global log_output, and the console display fallback) is
+        // suppressed to avoid writing the same output twice. The buffer is
+        // still retained for email_output, and the error path is untouched.
+        if ($this->realtimeOutputEnabled()) {
+            $this->emailOutput($event);
+
+            return;
+        }
+
         $logged = false;
         $logOutput = $this->configuration
             ->get('log_output')
@@ -195,15 +214,7 @@ class EventRunner
             $this->display($event->getOutputStream());
         }
 
-        $emailOutput = $this->configuration
-            ->get('email_output')
-        ;
-        if ($emailOutput && !empty($event->getOutputStream())) {
-            $this->mailer->send(
-                'Crunz: output for event: ' . ($event->description ?? $event->getId()),
-                $this->formatEventOutput($event)
-            );
-        }
+        $this->emailOutput($event);
     }
 
     protected function handleError(Event $event): void
@@ -269,6 +280,26 @@ class EventRunner
         ;
     }
 
+    /**
+     * Email the event's output when email_output is enabled.
+     *
+     * Kept separate from the logging/display logic so it can run unchanged in
+     * realtime mode, where the live stream replaces the end-of-job logging but
+     * the retained buffer is still emailed.
+     */
+    private function emailOutput(Event $event): void
+    {
+        $emailOutput = $this->configuration
+            ->get('email_output')
+        ;
+        if ($emailOutput && !empty($event->getOutputStream())) {
+            $this->mailer->send(
+                'Crunz: output for event: ' . ($event->description ?? $event->getId()),
+                $this->formatEventOutput($event)
+            );
+        }
+    }
+
     private function pingBefore(PingableInterface $schedule): void
     {
         if (!$schedule->hasPingBefore()) {
@@ -310,5 +341,42 @@ class EventRunner
         }
 
         return $this->logger;
+    }
+
+    /** Whether realtime output streaming is enabled via configuration. */
+    private function realtimeOutputEnabled(): bool
+    {
+        return (bool) $this->configuration
+            ->get('output_realtime')
+        ;
+    }
+
+    /**
+     * Build a sink that writes each output chunk straight to the console as it
+     * is produced. Standard output goes to the main stream and error output to
+     * the console's error stream (when available). Chunks are written raw and
+     * without an added newline so task output is forwarded verbatim.
+     *
+     * @return \Closure(string, string):void
+     */
+    private function createRealtimeCallback(): \Closure
+    {
+        $output = $this->output;
+        if (null === $output) {
+            return static function (): void {};
+        }
+
+        $errorOutput = $output instanceof ConsoleOutputInterface
+            ? $output->getErrorOutput()
+            : $output
+        ;
+
+        return static function (string $type, string $content) use ($output, $errorOutput): void {
+            $stream = SymfonyProcess::ERR === $type
+                ? $errorOutput
+                : $output
+            ;
+            $stream->write($content, false, OutputInterface::OUTPUT_RAW);
+        };
     }
 }

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -182,17 +182,6 @@ class EventRunner
 
     protected function handleOutput(Event $event): void
     {
-        // In realtime mode the task's successful output has already been
-        // streamed live to the console, so the end-of-job emission (per-event
-        // log, global log_output, and the console display fallback) is
-        // suppressed to avoid writing the same output twice. The buffer is
-        // still retained for email_output, and the error path is untouched.
-        if ($this->realtimeOutputEnabled()) {
-            $this->emailOutput($event);
-
-            return;
-        }
-
         $logged = false;
         $logOutput = $this->configuration
             ->get('log_output')
@@ -210,7 +199,13 @@ class EventRunner
             $logged = true;
         }
 
-        if (!$logged) {
+        // The display() fallback writes the task output straight to the runner's
+        // console. In realtime mode that same output has already been streamed
+        // live to the console, so suppress this fallback to avoid printing it
+        // twice. Logger-based sinks (per-event log files, global log_output) and
+        // email are NOT suppressed: they write to their own configured
+        // destinations, so they do not duplicate the live console stream.
+        if (!$logged && !$this->realtimeOutputEnabled()) {
             $this->display($event->getOutputStream());
         }
 
@@ -230,7 +225,10 @@ class EventRunner
             $this->logger()
                 ->error($this->formatEventError($event))
             ;
-        } else {
+        } elseif (!$this->realtimeOutputEnabled()) {
+            // Without log_errors, a failed task's output is written straight to
+            // the runner's console here. In realtime mode that output already
+            // streamed live, so suppress this write to avoid duplicating it.
             $output = $event->wholeOutput();
 
             $this->output

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -21,6 +21,14 @@ class EventRunner
     /** @var Logger|null */
     protected $logger;
     private ?OutputInterface $output = null;
+    /**
+     * Open stream handles used to stream realtime output to a file/stream
+     * destination, keyed by the event's object id. Closed once the event is
+     * handled.
+     *
+     * @var array<int,resource>
+     */
+    private array $realtimeStreams = [];
 
     public function __construct(
         protected Invoker $invoker,
@@ -77,10 +85,11 @@ class EventRunner
             $event->logger = $this->loggerFactory->createEvent($event->output);
         }
 
-        // When realtime output is enabled, stream the task's output to the
-        // console as it is produced instead of only after the process exits.
+        // When realtime output is enabled, stream the task's output to its
+        // resolved destination (per-event file, global log file, or the console)
+        // as it is produced instead of only after the process exits.
         if ($this->realtimeOutputEnabled()) {
-            $event->setRealtimeCallback($this->createRealtimeCallback());
+            $event->setRealtimeCallback($this->createRealtimeCallback($event));
         }
 
         $this->consoleLogger
@@ -140,6 +149,9 @@ class EventRunner
                     $this->consoleLogger
                         ->debug("Task <info>{$id}</info> status: {$runStatus}.");
 
+                    // Close any realtime file stream opened for this event.
+                    $this->closeRealtimeStream($event);
+
                     // Dismiss the event if it's finished
                     $schedule->dismissEvent($eventKey);
                 }
@@ -182,6 +194,17 @@ class EventRunner
 
     protected function handleOutput(Event $event): void
     {
+        // In realtime mode the task's output has already been streamed, as it
+        // was produced, to its resolved destination (per-event file, global log
+        // file, or the console). The end-of-job framed emission to that same
+        // destination is replaced by the live stream, so it is skipped here.
+        // email_output is additive and still sends from the retained buffer.
+        if ($this->realtimeOutputEnabled()) {
+            $this->emailOutput($event);
+
+            return;
+        }
+
         $logged = false;
         $logOutput = $this->configuration
             ->get('log_output')
@@ -199,13 +222,7 @@ class EventRunner
             $logged = true;
         }
 
-        // The display() fallback writes the task output straight to the runner's
-        // console. In realtime mode that same output has already been streamed
-        // live to the console, so suppress this fallback to avoid printing it
-        // twice. Logger-based sinks (per-event log files, global log_output) and
-        // email are NOT suppressed: they write to their own configured
-        // destinations, so they do not duplicate the live console stream.
-        if (!$logged && !$this->realtimeOutputEnabled()) {
+        if (!$logged) {
             $this->display($event->getOutputStream());
         }
 
@@ -350,15 +367,30 @@ class EventRunner
     }
 
     /**
-     * Build a sink that writes each output chunk straight to the console as it
-     * is produced. Standard output goes to the main stream and error output to
-     * the console's error stream (when available). Chunks are written raw and
+     * Build a sink that writes each output chunk to the event's resolved output
+     * destination as it is produced. When the destination is a file/stream path
+     * (a per-event `sendOutputTo()` target or the global `output_log_file`), the
+     * raw chunks are appended to that path. Otherwise output is written to the
+     * runner console, with standard output going to the main stream and error
+     * output to the error stream (when available). Chunks are written raw and
      * without an added newline so task output is forwarded verbatim.
      *
      * @return \Closure(string, string):void
      */
-    private function createRealtimeCallback(): \Closure
+    private function createRealtimeCallback(Event $event): \Closure
     {
+        $path = $this->realtimeStreamPath($event);
+        if (null !== $path) {
+            $stream = @\fopen($path, 'ab');
+            if (false !== $stream) {
+                $this->realtimeStreams[\spl_object_id($event)] = $stream;
+
+                return static function (string $type, string $content) use ($stream): void {
+                    \fwrite($stream, $content);
+                };
+            }
+        }
+
         $output = $this->output;
         if (null === $output) {
             return static function (): void {};
@@ -376,5 +408,44 @@ class EventRunner
             ;
             $stream->write($content, false, OutputInterface::OUTPUT_RAW);
         };
+    }
+
+    /**
+     * Resolve the file/stream path a task's realtime output should be streamed
+     * to, mirroring the success-path routing precedence: a dedicated per-event
+     * output file first, then the global output log file. Returns null when the
+     * output is not directed at a file/stream and should go to the console.
+     */
+    private function realtimeStreamPath(Event $event): ?string
+    {
+        if (!$event->nullOutput()) {
+            return $event->output;
+        }
+
+        $logOutput = (bool) $this->configuration
+            ->get('log_output')
+        ;
+        if ($logOutput) {
+            $logFile = $this->configuration
+                ->get('output_log_file')
+            ;
+            if (\is_string($logFile) && '' !== $logFile) {
+                return $logFile;
+            }
+        }
+
+        return null;
+    }
+
+    /** Close and forget any realtime stream opened for the given event. */
+    private function closeRealtimeStream(Event $event): void
+    {
+        $id = \spl_object_id($event);
+        if (!isset($this->realtimeStreams[$id])) {
+            return;
+        }
+
+        \fclose($this->realtimeStreams[$id]);
+        unset($this->realtimeStreams[$id]);
     }
 }

--- a/tests/EndToEnd/RealtimeOutputTest.php
+++ b/tests/EndToEnd/RealtimeOutputTest.php
@@ -72,6 +72,36 @@ final class RealtimeOutputTest extends EndToEndTestCase
         self::assertStringContainsString('REALTIME_SECOND', $process->getOutput());
     }
 
+    public function test_output_is_streamed_to_file_before_task_finishes(): void
+    {
+        $envBuilder = $this->createEnvironmentBuilder()
+            ->addTask('RealtimeFileOutputTasks')
+            ->withConfig(['output_realtime' => true])
+        ;
+        $environment = $envBuilder->createEnvironment();
+        $logPath = $environment->rootDirectory() . DIRECTORY_SEPARATOR . 'realtime.log';
+
+        $process = $environment->runCrunzCommand('schedule:run --force', wait: false);
+
+        // The task (configured with appendOutputTo('realtime.log')) emits the
+        // first marker, sleeps 3s, then emits the second. With realtime output
+        // the file receives the first marker before the second is produced.
+        $streamedIncrementally = $this->fileSawFirstMarkerBeforeSecond($logPath, $process);
+
+        $process->wait();
+
+        self::assertTrue(
+            $streamedIncrementally,
+            'The log file should receive the first marker before the second is produced (realtime file streaming).'
+        );
+        // Both markers are present in the file once the task completes, and the
+        // raw output is streamed (not wrapped in the framed log record).
+        $contents = (string) \file_get_contents($logPath);
+        self::assertStringContainsString('FILE_FIRST', $contents);
+        self::assertStringContainsString('FILE_SECOND', $contents);
+        self::assertStringNotContainsString('crunz.INFO', $contents);
+    }
+
     /**
      * Poll the process output while it runs, returning true if we ever observe
      * the first marker present while the second is still absent. That transient
@@ -88,6 +118,37 @@ final class RealtimeOutputTest extends EndToEndTestCase
             if (
                 \str_contains($output, 'REALTIME_FIRST')
                 && !\str_contains($output, 'REALTIME_SECOND')
+            ) {
+                return true;
+            }
+
+            if (\microtime(true) > $deadline) {
+                break;
+            }
+
+            \usleep(50000); // 50 ms
+        }
+
+        return false;
+    }
+
+    /**
+     * Poll a log file while the process runs, returning true if we ever observe
+     * the first marker written to the file while the second is still absent —
+     * proving the file is written incrementally rather than only at the end.
+     */
+    private function fileSawFirstMarkerBeforeSecond(string $logPath, Process $process): bool
+    {
+        $deadline = \microtime(true) + self::POLL_TIMEOUT_SECONDS;
+
+        while ($process->isRunning()) {
+            $contents = \is_file($logPath)
+                ? (string) \file_get_contents($logPath)
+                : ''
+            ;
+            if (
+                \str_contains($contents, 'FILE_FIRST')
+                && !\str_contains($contents, 'FILE_SECOND')
             ) {
                 return true;
             }

--- a/tests/EndToEnd/RealtimeOutputTest.php
+++ b/tests/EndToEnd/RealtimeOutputTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\EndToEnd;
+
+use Crunz\Process\Process;
+use Crunz\Tests\TestCase\EndToEndTestCase;
+
+final class RealtimeOutputTest extends EndToEndTestCase
+{
+    /** Seconds to wait for the first marker before giving up. */
+    private const POLL_TIMEOUT_SECONDS = 15.0;
+
+    public function test_output_is_streamed_before_task_finishes(): void
+    {
+        $envBuilder = $this->createEnvironmentBuilder()
+            ->addTask('RealtimeOutputTasks')
+            ->withConfig(['output_realtime' => true])
+        ;
+        $environment = $envBuilder->createEnvironment();
+
+        $process = $environment->runCrunzCommand('schedule:run --force', wait: false);
+
+        // The task emits the first marker, sleeps 3s, then emits the second.
+        // In realtime mode each chunk is streamed as produced, so there is a
+        // window where the first marker is visible but the second is not yet.
+        $streamedIncrementally = $this->sawFirstMarkerBeforeSecond($process);
+
+        $process->wait();
+
+        self::assertTrue(
+            $streamedIncrementally,
+            'The first marker should be streamed before the second is produced (realtime streaming).'
+        );
+        // Sanity check: both markers are present once the task completes.
+        self::assertStringContainsString('REALTIME_FIRST', $process->getOutput());
+        self::assertStringContainsString('REALTIME_SECOND', $process->getOutput());
+    }
+
+    public function test_output_is_not_streamed_when_realtime_disabled(): void
+    {
+        $envBuilder = $this->createEnvironmentBuilder()
+            ->addTask('RealtimeOutputTasks')
+            ->withConfig(
+                [
+                    'output_realtime' => false,
+                    // Route the end-of-job output to stdout so we can confirm it
+                    // arrives all at once at the end, not streamed during the run.
+                    'log_output' => true,
+                    'output_log_file' => 'php://stdout',
+                ]
+            )
+        ;
+        $environment = $envBuilder->createEnvironment();
+
+        $process = $environment->runCrunzCommand('schedule:run --force', wait: false);
+
+        // With realtime off, both markers are buffered and written together in a
+        // single end-of-job record, so the "first without second" window never
+        // exists.
+        $streamedIncrementally = $this->sawFirstMarkerBeforeSecond($process);
+
+        $process->wait();
+
+        self::assertFalse(
+            $streamedIncrementally,
+            'With realtime disabled the markers must be emitted together at the end, not streamed.'
+        );
+        // The output is still emitted at the end of the job.
+        self::assertStringContainsString('REALTIME_FIRST', $process->getOutput());
+        self::assertStringContainsString('REALTIME_SECOND', $process->getOutput());
+    }
+
+    /**
+     * Poll the process output while it runs, returning true if we ever observe
+     * the first marker present while the second is still absent. That transient
+     * state only occurs when output is streamed incrementally; when output is
+     * buffered, both markers appear together in one write and the state is never
+     * observed.
+     */
+    private function sawFirstMarkerBeforeSecond(Process $process): bool
+    {
+        $deadline = \microtime(true) + self::POLL_TIMEOUT_SECONDS;
+
+        while ($process->isRunning()) {
+            $output = $process->getOutput();
+            if (
+                \str_contains($output, 'REALTIME_FIRST')
+                && !\str_contains($output, 'REALTIME_SECOND')
+            ) {
+                return true;
+            }
+
+            if (\microtime(true) > $deadline) {
+                break;
+            }
+
+            \usleep(50000); // 50 ms
+        }
+
+        return false;
+    }
+}

--- a/tests/TestCase/FakeConfiguration.php
+++ b/tests/TestCase/FakeConfiguration.php
@@ -18,6 +18,7 @@ final class FakeConfiguration implements ConfigurationInterface
         'errors_log_file' => null,
         'logger_factory' => PsrStreamLoggerFactory::class,
         'log_output' => false,
+        'output_realtime' => false,
         'output_log_file' => null,
         'log_allow_line_breaks' => false,
         'log_ignore_empty_context' => false,

--- a/tests/TestCase/SpyConsoleOutput.php
+++ b/tests/TestCase/SpyConsoleOutput.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\TestCase;
+
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * A {@see ConsoleOutputInterface} test double that captures the main output and
+ * the error output into separate buffers, so tests can assert how output is
+ * routed between stdout and stderr (the real {@see BufferedOutput} used
+ * elsewhere is not a console output and collapses both streams into one).
+ */
+final class SpyConsoleOutput extends BufferedOutput implements ConsoleOutputInterface
+{
+    private BufferedOutput $stderr;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->stderr = new BufferedOutput();
+    }
+
+    public function getErrorOutput(): OutputInterface
+    {
+        return $this->stderr;
+    }
+
+    public function setErrorOutput(OutputInterface $error): void
+    {
+        // Not needed for tests.
+    }
+
+    public function section(): ConsoleSectionOutput
+    {
+        throw new \BadMethodCallException('section() is not supported by the test double.');
+    }
+
+    /** Return everything written to the error (stderr) stream. */
+    public function fetchErrorOutput(): string
+    {
+        return $this->stderr
+            ->fetch();
+    }
+}

--- a/tests/Unit/EventRunnerTest.php
+++ b/tests/Unit/EventRunnerTest.php
@@ -8,12 +8,10 @@ use Crunz\EventRunner;
 use Crunz\HttpClient\HttpClientInterface;
 use Crunz\Invoker;
 use Crunz\Logger\ConsoleLoggerInterface;
-use Crunz\Logger\Logger;
 use Crunz\Logger\LoggerFactory;
 use Crunz\Mailer;
 use Crunz\Schedule;
 use Crunz\Tests\TestCase\FakeConfiguration;
-use Crunz\Tests\TestCase\Logger\SpyPsrLogger;
 use Crunz\Tests\TestCase\SpyConsoleOutput;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -115,95 +113,73 @@ final class EventRunnerTest extends TestCase
         self::assertSame(1, \substr_count($captured, 'RUNNER_BUFFERED_MARKER'));
     }
 
-    public function test_realtime_output_still_writes_global_log_output_record(): void
+    public function test_realtime_output_streams_to_global_log_file(): void
     {
-        // Logger-based sinks write to their own configured destination, so they
-        // do NOT duplicate the live console stream and must keep working in
-        // realtime mode. Only the console display() fallback is suppressed.
-        $command = "php -r \"echo 'GLOBAL_LOG';\"";
+        // With log_output enabled, realtime streams the raw output to the global
+        // output_log_file as it is produced (replacing the end-of-job framed
+        // record), so a file target is written live, not dropped.
+        $logFile = \tempnam(\sys_get_temp_dir(), 'crunz_rt_global_');
+        self::assertIsString($logFile);
 
-        $schedule = new Schedule();
-        $schedule->run($command)
-            ->everyMinute()
-        ;
+        try {
+            $command = "php -r \"echo 'GLOBAL_FILE_OUTPUT';\"";
 
-        $spyLogger = new SpyPsrLogger();
-        $loggerFactory = $this->createMock(LoggerFactory::class);
-        $loggerFactory->method('create')
-            ->willReturn(new Logger($spyLogger))
-        ;
+            $schedule = new Schedule();
+            $schedule->run($command)
+                ->everyMinute()
+            ;
 
-        $eventRunner = new EventRunner(
-            new Invoker(),
-            new FakeConfiguration(
-                [
-                    'output_realtime' => true,
-                    'log_output' => true,
-                    'output_log_file' => 'main.log',
-                ]
-            ),
-            $this->createMock(Mailer::class),
-            $loggerFactory,
-            $this->createMock(HttpClientInterface::class),
-            $this->createMock(ConsoleLoggerInterface::class)
-        );
+            $eventRunner = $this->createEventRunner(
+                realInvoker: true,
+                configuration: new FakeConfiguration(
+                    [
+                        'output_realtime' => true,
+                        'log_output' => true,
+                        'output_log_file' => $logFile,
+                    ]
+                ),
+            );
 
-        $eventRunner->handle(new BufferedOutput(), [$schedule]);
+            $eventRunner->handle(new BufferedOutput(), [$schedule]);
 
-        $infoLogs = \array_filter(
-            $spyLogger->getLogs(),
-            static fn (array $log): bool => 'info' === $log['level']
-        );
-        self::assertCount(
-            1,
-            $infoLogs,
-            'Global log_output record must still be written in realtime mode.'
-        );
+            $contents = (string) \file_get_contents($logFile);
+            self::assertStringContainsString('GLOBAL_FILE_OUTPUT', $contents);
+            // Streamed raw, not as the framed end-of-job log record.
+            self::assertStringNotContainsString('crunz.INFO', $contents);
+        } finally {
+            @\unlink($logFile);
+        }
     }
 
-    public function test_realtime_output_still_writes_per_event_log_file(): void
+    public function test_realtime_output_streams_to_per_event_log_file(): void
     {
-        // A task with appendOutputTo()/sendOutputTo() writes to a dedicated file
-        // via its own logger; that file is a separate sink from the console, so
-        // realtime mode must not drop it.
-        $command = "php -r \"echo 'PER_EVENT';\"";
+        // A task with sendOutputTo()/appendOutputTo() streams its raw output to
+        // that dedicated file as it is produced.
+        $logFile = \tempnam(\sys_get_temp_dir(), 'crunz_rt_per_event_');
+        self::assertIsString($logFile);
 
-        $schedule = new Schedule();
-        $schedule->run($command)
-            ->everyMinute()
-            ->appendOutputTo('event.log')
-        ;
+        try {
+            $command = "php -r \"echo 'PER_EVENT_FILE_OUTPUT';\"";
 
-        $eventSpyLogger = new SpyPsrLogger();
-        $loggerFactory = $this->createMock(LoggerFactory::class);
-        $loggerFactory->method('create')
-            ->willReturn(new Logger(new SpyPsrLogger()))
-        ;
-        $loggerFactory->method('createEvent')
-            ->willReturn(new Logger($eventSpyLogger))
-        ;
+            $schedule = new Schedule();
+            $schedule->run($command)
+                ->everyMinute()
+                ->appendOutputTo($logFile)
+            ;
 
-        $eventRunner = new EventRunner(
-            new Invoker(),
-            new FakeConfiguration(['output_realtime' => true]),
-            $this->createMock(Mailer::class),
-            $loggerFactory,
-            $this->createMock(HttpClientInterface::class),
-            $this->createMock(ConsoleLoggerInterface::class)
-        );
+            $eventRunner = $this->createEventRunner(
+                realInvoker: true,
+                configuration: new FakeConfiguration(['output_realtime' => true]),
+            );
 
-        $eventRunner->handle(new BufferedOutput(), [$schedule]);
+            $eventRunner->handle(new BufferedOutput(), [$schedule]);
 
-        $infoLogs = \array_filter(
-            $eventSpyLogger->getLogs(),
-            static fn (array $log): bool => 'info' === $log['level']
-        );
-        self::assertCount(
-            1,
-            $infoLogs,
-            'Per-event log file must still be written in realtime mode.'
-        );
-        self::assertStringContainsString('PER_EVENT', (string) \reset($infoLogs)['message']);
+            $contents = (string) \file_get_contents($logFile);
+            self::assertStringContainsString('PER_EVENT_FILE_OUTPUT', $contents);
+            self::assertStringNotContainsString('crunz.INFO', $contents);
+        } finally {
+            @\unlink($logFile);
+        }
     }
 
     public function test_realtime_output_still_sends_email(): void

--- a/tests/Unit/EventRunnerTest.php
+++ b/tests/Unit/EventRunnerTest.php
@@ -8,11 +8,14 @@ use Crunz\EventRunner;
 use Crunz\HttpClient\HttpClientInterface;
 use Crunz\Invoker;
 use Crunz\Logger\ConsoleLoggerInterface;
+use Crunz\Logger\Logger;
 use Crunz\Logger\LoggerFactory;
 use Crunz\Mailer;
 use Crunz\Schedule;
 use Crunz\Tests\TestCase\FakeConfiguration;
+use Crunz\Tests\TestCase\Logger\SpyPsrLogger;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\StoreInterface;
@@ -47,6 +50,115 @@ final class EventRunnerTest extends TestCase
         $event->thenPing($url);
 
         $eventRunner->handle($output, [$schedule]);
+    }
+
+    public function test_realtime_output_is_streamed_raw_and_once(): void
+    {
+        // Output contains a Symfony style tag. The realtime path writes raw, so
+        // the tag survives verbatim; the end-of-job display() path runs through
+        // the output formatter, which would strip the tag. Asserting the literal
+        // tag survives proves the realtime path produced the output.
+        $taskOutput = '<info>RUNNER_REALTIME_MARKER</info>';
+        $command = "php -r \"echo '{$taskOutput}';\"";
+
+        $schedule = new Schedule();
+        $schedule->run($command)
+            ->everyMinute()
+        ;
+
+        $output = new BufferedOutput();
+        $eventRunner = $this->createEventRunner(
+            realInvoker: true,
+            configuration: new FakeConfiguration(['output_realtime' => true]),
+        );
+
+        $eventRunner->handle($output, [$schedule]);
+
+        $captured = $output->fetch();
+
+        // Streamed verbatim (raw), not formatter-stripped.
+        self::assertStringContainsString($taskOutput, $captured);
+        // Exactly once: the realtime stream replaces the end-of-job console
+        // emission, so display() must not also write the same output.
+        self::assertSame(
+            1,
+            \substr_count($captured, 'RUNNER_REALTIME_MARKER'),
+            'Realtime output must not be duplicated by the end-of-job emission.'
+        );
+    }
+
+    public function test_output_is_not_streamed_raw_when_realtime_disabled(): void
+    {
+        $taskOutput = '<info>RUNNER_BUFFERED_MARKER</info>';
+        $command = "php -r \"echo '{$taskOutput}';\"";
+
+        $schedule = new Schedule();
+        $schedule->run($command)
+            ->everyMinute()
+        ;
+
+        $output = new BufferedOutput();
+        $eventRunner = $this->createEventRunner(
+            realInvoker: true,
+            configuration: new FakeConfiguration(['output_realtime' => false]),
+        );
+
+        $eventRunner->handle($output, [$schedule]);
+
+        $captured = $output->fetch();
+
+        // With realtime off, output still reaches the console once, via the
+        // existing end-of-job display() path (which strips the style tag).
+        self::assertStringContainsString('RUNNER_BUFFERED_MARKER', $captured);
+        self::assertStringNotContainsString($taskOutput, $captured);
+        self::assertSame(1, \substr_count($captured, 'RUNNER_BUFFERED_MARKER'));
+    }
+
+    public function test_realtime_output_suppresses_end_of_job_log_record(): void
+    {
+        // This is the core fix for issue #83 in the reporter's configuration
+        // (log_output: true, output_log_file: php://stdout): the realtime stream
+        // replaces the end-of-job structured record, so output is not written to
+        // stdout twice.
+        $command = "php -r \"echo 'NO_DOUBLE_LOG';\"";
+
+        $schedule = new Schedule();
+        $schedule->run($command)
+            ->everyMinute()
+        ;
+
+        $spyLogger = new SpyPsrLogger();
+        $loggerFactory = $this->createMock(LoggerFactory::class);
+        $loggerFactory->method('create')
+            ->willReturn(new Logger($spyLogger))
+        ;
+
+        $eventRunner = new EventRunner(
+            new Invoker(),
+            new FakeConfiguration(
+                [
+                    'output_realtime' => true,
+                    'log_output' => true,
+                    'output_log_file' => 'php://stdout',
+                ]
+            ),
+            $this->createMock(Mailer::class),
+            $loggerFactory,
+            $this->createMock(HttpClientInterface::class),
+            $this->createMock(ConsoleLoggerInterface::class)
+        );
+
+        $eventRunner->handle(new BufferedOutput(), [$schedule]);
+
+        $infoLogs = \array_filter(
+            $spyLogger->getLogs(),
+            static fn (array $log): bool => 'info' === $log['level']
+        );
+        self::assertCount(
+            0,
+            $infoLogs,
+            'Successful output must not be logged again at end of job in realtime mode.'
+        );
     }
 
     public function test_event_logging_configuration(): void
@@ -130,8 +242,10 @@ final class EventRunnerTest extends TestCase
         );
     }
 
-    private function createEventRunner(bool $realInvoker = false): EventRunner
-    {
+    private function createEventRunner(
+        bool $realInvoker = false,
+        ?FakeConfiguration $configuration = null,
+    ): EventRunner {
         $invoker = true === $realInvoker
             ? new Invoker()
             : $this->createMock(Invoker::class)
@@ -143,7 +257,7 @@ final class EventRunnerTest extends TestCase
 
         return new EventRunner(
             $invoker,
-            new FakeConfiguration(),
+            $configuration ?? new FakeConfiguration(),
             $mailer,
             $loggerFactory,
             $httpClient,

--- a/tests/Unit/EventRunnerTest.php
+++ b/tests/Unit/EventRunnerTest.php
@@ -14,6 +14,7 @@ use Crunz\Mailer;
 use Crunz\Schedule;
 use Crunz\Tests\TestCase\FakeConfiguration;
 use Crunz\Tests\TestCase\Logger\SpyPsrLogger;
+use Crunz\Tests\TestCase\SpyConsoleOutput;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -114,13 +115,12 @@ final class EventRunnerTest extends TestCase
         self::assertSame(1, \substr_count($captured, 'RUNNER_BUFFERED_MARKER'));
     }
 
-    public function test_realtime_output_suppresses_end_of_job_log_record(): void
+    public function test_realtime_output_still_writes_global_log_output_record(): void
     {
-        // This is the core fix for issue #83 in the reporter's configuration
-        // (log_output: true, output_log_file: php://stdout): the realtime stream
-        // replaces the end-of-job structured record, so output is not written to
-        // stdout twice.
-        $command = "php -r \"echo 'NO_DOUBLE_LOG';\"";
+        // Logger-based sinks write to their own configured destination, so they
+        // do NOT duplicate the live console stream and must keep working in
+        // realtime mode. Only the console display() fallback is suppressed.
+        $command = "php -r \"echo 'GLOBAL_LOG';\"";
 
         $schedule = new Schedule();
         $schedule->run($command)
@@ -139,7 +139,7 @@ final class EventRunnerTest extends TestCase
                 [
                     'output_realtime' => true,
                     'log_output' => true,
-                    'output_log_file' => 'php://stdout',
+                    'output_log_file' => 'main.log',
                 ]
             ),
             $this->createMock(Mailer::class),
@@ -155,9 +155,146 @@ final class EventRunnerTest extends TestCase
             static fn (array $log): bool => 'info' === $log['level']
         );
         self::assertCount(
-            0,
+            1,
             $infoLogs,
-            'Successful output must not be logged again at end of job in realtime mode.'
+            'Global log_output record must still be written in realtime mode.'
+        );
+    }
+
+    public function test_realtime_output_still_writes_per_event_log_file(): void
+    {
+        // A task with appendOutputTo()/sendOutputTo() writes to a dedicated file
+        // via its own logger; that file is a separate sink from the console, so
+        // realtime mode must not drop it.
+        $command = "php -r \"echo 'PER_EVENT';\"";
+
+        $schedule = new Schedule();
+        $schedule->run($command)
+            ->everyMinute()
+            ->appendOutputTo('event.log')
+        ;
+
+        $eventSpyLogger = new SpyPsrLogger();
+        $loggerFactory = $this->createMock(LoggerFactory::class);
+        $loggerFactory->method('create')
+            ->willReturn(new Logger(new SpyPsrLogger()))
+        ;
+        $loggerFactory->method('createEvent')
+            ->willReturn(new Logger($eventSpyLogger))
+        ;
+
+        $eventRunner = new EventRunner(
+            new Invoker(),
+            new FakeConfiguration(['output_realtime' => true]),
+            $this->createMock(Mailer::class),
+            $loggerFactory,
+            $this->createMock(HttpClientInterface::class),
+            $this->createMock(ConsoleLoggerInterface::class)
+        );
+
+        $eventRunner->handle(new BufferedOutput(), [$schedule]);
+
+        $infoLogs = \array_filter(
+            $eventSpyLogger->getLogs(),
+            static fn (array $log): bool => 'info' === $log['level']
+        );
+        self::assertCount(
+            1,
+            $infoLogs,
+            'Per-event log file must still be written in realtime mode.'
+        );
+        self::assertStringContainsString('PER_EVENT', (string) \reset($infoLogs)['message']);
+    }
+
+    public function test_realtime_output_still_sends_email(): void
+    {
+        $command = "php -r \"echo 'MAIL_BODY';\"";
+
+        $schedule = new Schedule();
+        $schedule->run($command)
+            ->everyMinute()
+        ;
+
+        $mailer = $this->createMock(Mailer::class);
+        $mailer->expects(self::once())
+            ->method('send')
+        ;
+
+        $eventRunner = new EventRunner(
+            new Invoker(),
+            new FakeConfiguration(
+                [
+                    'output_realtime' => true,
+                    'email_output' => true,
+                ]
+            ),
+            $mailer,
+            $this->createMock(LoggerFactory::class),
+            $this->createMock(HttpClientInterface::class),
+            $this->createMock(ConsoleLoggerInterface::class)
+        );
+
+        $eventRunner->handle(new BufferedOutput(), [$schedule]);
+    }
+
+    public function test_realtime_routes_stderr_to_error_stream(): void
+    {
+        // With a real console output, stdout chunks go to the main stream and
+        // stderr chunks to the error stream.
+        $command = "php -r \"echo 'OUTCHUNK'; fwrite(STDERR, 'ERRCHUNK');\"";
+
+        $schedule = new Schedule();
+        $schedule->run($command)
+            ->everyMinute()
+        ;
+
+        $output = new SpyConsoleOutput();
+        $eventRunner = $this->createEventRunner(
+            realInvoker: true,
+            configuration: new FakeConfiguration(['output_realtime' => true]),
+        );
+
+        $eventRunner->handle($output, [$schedule]);
+
+        $stdout = $output->fetch();
+        $stderr = $output->fetchErrorOutput();
+
+        self::assertStringContainsString('OUTCHUNK', $stdout);
+        self::assertStringNotContainsString('ERRCHUNK', $stdout);
+        self::assertStringContainsString('ERRCHUNK', $stderr);
+    }
+
+    public function test_realtime_output_does_not_duplicate_failed_task_output(): void
+    {
+        // A failing task streams its output live; handleError must NOT also write
+        // the <error> blob in realtime mode, otherwise the output appears twice.
+        $command = "php -r \"fwrite(STDERR, 'BOOM'); exit(1);\"";
+
+        $schedule = new Schedule();
+        $schedule->run($command)
+            ->everyMinute()
+        ;
+
+        $output = new BufferedOutput();
+        $eventRunner = $this->createEventRunner(
+            realInvoker: true,
+            configuration: new FakeConfiguration(
+                [
+                    'output_realtime' => true,
+                    'log_errors' => false,
+                ]
+            ),
+        );
+
+        $eventRunner->handle($output, [$schedule]);
+
+        $captured = $output->fetch();
+
+        self::assertStringContainsString('BOOM', $captured);
+        self::assertSame(
+            1,
+            \substr_count($captured, 'BOOM'),
+            'Failed task output must not be duplicated by handleError in realtime mode.'
         );
     }
 

--- a/tests/Unit/EventRunnerTest.php
+++ b/tests/Unit/EventRunnerTest.php
@@ -81,7 +81,7 @@ final class EventRunnerTest extends TestCase
         // emission, so display() must not also write the same output.
         self::assertSame(
             1,
-            \substr_count($captured, 'RUNNER_REALTIME_MARKER'),
+            \mb_substr_count($captured, 'RUNNER_REALTIME_MARKER'),
             'Realtime output must not be duplicated by the end-of-job emission.'
         );
     }
@@ -110,7 +110,7 @@ final class EventRunnerTest extends TestCase
         // existing end-of-job display() path (which strips the style tag).
         self::assertStringContainsString('RUNNER_BUFFERED_MARKER', $captured);
         self::assertStringNotContainsString($taskOutput, $captured);
-        self::assertSame(1, \substr_count($captured, 'RUNNER_BUFFERED_MARKER'));
+        self::assertSame(1, \mb_substr_count($captured, 'RUNNER_BUFFERED_MARKER'));
     }
 
     public function test_realtime_output_streams_to_global_log_file(): void
@@ -269,7 +269,7 @@ final class EventRunnerTest extends TestCase
         self::assertStringContainsString('BOOM', $captured);
         self::assertSame(
             1,
-            \substr_count($captured, 'BOOM'),
+            \mb_substr_count($captured, 'BOOM'),
             'Failed task output must not be duplicated by handleError in realtime mode.'
         );
     }

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -403,6 +403,32 @@ final class EventTest extends UnitTestCase
     }
 
     /** @test */
+    public function realtime_callback_receives_output_as_it_is_produced(): void
+    {
+        $command = "php -r \"echo 'Realtime output';\"";
+        $event = new Event(\uniqid('c', true), $command);
+
+        $collected = '';
+        $event->setRealtimeCallback(
+            static function (string $type, string $content) use (&$collected): void {
+                $collected .= $content;
+            }
+        );
+
+        $event->start();
+        $process = $event->getProcess();
+
+        while ($process->isRunning()) {
+            \usleep(20000); // wait 20 ms
+        }
+
+        self::assertStringContainsString('Realtime output', $collected);
+        // The callback must observe exactly the same bytes that populate the
+        // in-memory buffer, so streaming and buffering never diverge.
+        self::assertSame($event->wholeOutput(), $collected);
+    }
+
+    /** @test */
     public function task_will_prevent_overlapping_with_default_store(): void
     {
         $this->assertPreventOverlapping();

--- a/tests/resources/tasks/RealtimeFileOutputTasks.php
+++ b/tests/resources/tasks/RealtimeFileOutputTasks.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Crunz\Schedule;
+
+$scheduler = new Schedule();
+$scheduler
+    ->run(
+        static function (): void {
+            // Emit the first marker and flush it, then sleep before emitting the
+            // second. With realtime output the chunks are written to the log file
+            // as they are produced, so the first marker reaches the file before
+            // the task finishes.
+            echo 'FILE_FIRST' . PHP_EOL;
+            \flush();
+
+            \sleep(3);
+
+            echo 'FILE_SECOND' . PHP_EOL;
+        }
+    )
+    ->description('Realtime file streaming task')
+    ->everyMinute()
+    ->appendOutputTo('realtime.log')
+;
+
+return $scheduler;

--- a/tests/resources/tasks/RealtimeOutputTasks.php
+++ b/tests/resources/tasks/RealtimeOutputTasks.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Crunz\Schedule;
+
+$scheduler = new Schedule();
+$scheduler
+    ->run(
+        static function (): void {
+            // Emit the first marker and flush it immediately, then sleep before
+            // emitting the second marker. This creates a window during which the
+            // first marker has been produced but the task has not yet finished,
+            // letting the test observe whether output is streamed in realtime.
+            echo 'REALTIME_FIRST' . PHP_EOL;
+            \flush();
+
+            \sleep(3);
+
+            echo 'REALTIME_SECOND' . PHP_EOL;
+        }
+    )
+    ->description('Realtime streaming task')
+    ->everyMinute()
+;
+
+return $scheduler;


### PR DESCRIPTION
Closes #83.

## What

Adds an opt-in `output_realtime` config flag (default `false`). When enabled, each task's output is streamed to its destination **as it is produced**, instead of being buffered and emitted only after the task process exits.

This addresses the long-standing request (originally lavary/crunz#152) to stream output for long-running tasks — e.g. a worker that polls a queue in a loop, whose logs are otherwise invisible until it ends, which is painful when logs are collected from the process' stdout (Docker/CloudWatch).

## Behavior

The output is streamed to the same destination it would normally be written to at the end of the job, resolved in the usual precedence:

1. a per-event log file, if the task uses `sendOutputTo()` / `appendOutputTo()`;
2. otherwise the global `output_log_file`, if `log_output` is enabled;
3. otherwise the console (`stdout` for standard output, `stderr` for errors).

So a task logging to a file gets that file written line-by-line as it runs, and a task whose output goes to `stdout` gets it streamed live. The live stream is the **raw** task output (not the framed `[date] crunz.INFO: ...` record), and it replaces the end-of-job framed record for that destination (so output is not written twice). `email_output` and the error sinks (`log_errors` → `errors_log_file`, `email_errors`) are unaffected.

```yaml
# crunz.yml
output_realtime: true
```

Default is `false`, so existing setups are unchanged.

## Notes / limitations

- Realtime changes **when and in what form** output is written, not how much is held in memory (the buffer is retained so `email_output` can send the complete output at the end).
- Only the task process' own output is streamed; output echoed by `before()`/`then()` callbacks still goes via `email_output`.
- If two sinks resolve to the same underlying stream (e.g. `output_log_file: php://stdout` plus a separate stdout consumer), output can appear twice on that stream — point the log at a real file or disable it when relying on the live stream.

## Tests

- Unit (`EventRunnerTest`, `EventTest`): raw streaming + no duplication; per-event and global log **files** receive the raw streamed output; `email_output` still sent; stderr routed to the error stream; failed-task output not duplicated.
- E2E (`RealtimeOutputTest`): proves true incremental streaming to **both** the console and a file (first marker present before the second is produced), plus a buffered-mode control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
