### PR TITLE
test: fix flaky preventOverlapping closure test on Windows CI

### DIFF
--- a/tests/EndToEnd/ClosureRunTest.php
+++ b/tests/EndToEnd/ClosureRunTest.php
@@ -53,7 +53,23 @@ final class ClosureRunTest extends EndToEndTestCase
         $secondCall = $environment->runCrunzCommand('schedule:run');
         $firstCall->wait();
 
-        self::assertStringContainsString('Done', $firstCall->getOutput());
-        self::assertStringContainsString('No event is due!', $secondCall->getOutput());
+        // preventOverlapping() guarantees that of two overlapping runs exactly
+        // one executes the task and the other is skipped as "not due". Which of
+        // the two processes wins the lock is NOT deterministic: PHP process
+        // startup latency varies (notably on Windows CI), so the second-spawned
+        // run can acquire the lock before the first. Assert the invariant over
+        // the combined output rather than assuming the first call always wins.
+        $combinedOutput = $firstCall->getOutput() . $secondCall->getOutput();
+
+        self::assertStringContainsString(
+            'Done',
+            $combinedOutput,
+            'Exactly one of the overlapping runs should execute the task.'
+        );
+        self::assertStringContainsString(
+            'No event is due!',
+            $combinedOutput,
+            'The overlapping run should be skipped because the lock is held.'
+        );
     }
 }


### PR DESCRIPTION
## Problem

`ClosureRunTest::test_prevent_overlapping_works_on_closures` is flaky on the Windows CI matrix cell (e.g. `8.2 / Symfony ~6.4.0 / highest / windows-2022`), failing with:

```
Failed asserting that 'No event is due!\r\n...' [contains] 'Done'
tests/EndToEnd/ClosureRunTest.php:56
```

## Root cause

The test spawns two `schedule:run` processes 50ms apart and asserts that the **first** one acquires the `preventOverlapping()` lock and runs the task (`"Done"`), while the **second** is skipped (`"No event is due!"`):

```php
self::assertStringContainsString('Done', $firstCall->getOutput());
self::assertStringContainsString('No event is due!', $secondCall->getOutput());
```

But which process wins the lock is **not** determined by spawn order — it depends on PHP process-startup latency. On slow runners (notably Windows, which has no `fork` and pays a high process-creation cost), the second-spawned run can reach the lock-acquire step first. It then runs the task, and the *first* run is the one skipped — so `$firstCall` outputs `"No event is due!"` and the line-56 assertion for `"Done"` fails. The 50ms head-start only makes the intended ordering *likely*, not guaranteed.

## Fix

Assert the actual invariant `preventOverlapping()` guarantees — of two overlapping runs, exactly one executes the task and the other is skipped — **regardless of which process won the lock race**, by checking the combined output of both runs:

```php
$combinedOutput = $firstCall->getOutput() . $secondCall->getOutput();
self::assertStringContainsString('Done', $combinedOutput);
self::assertStringContainsString('No event is due!', $combinedOutput);
```

This still fails if overlap is *not* prevented (both runs would print `"Done"` and neither `"No event is due!"`), so the test keeps its protective value; it just no longer assumes the first-spawned process always wins the race.

Test-only change; no library behavior is affected. Verified passing locally (3 consecutive runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
